### PR TITLE
Add multi-tenant with-data image

### DIFF
--- a/.github/workflows/release-images.yaml
+++ b/.github/workflows/release-images.yaml
@@ -35,9 +35,11 @@ jobs:
         run: |
           cd images/
           make api-server-with-data
+          make api-server-with-data-mt
 
       - name: Publish images
         run: |
           cd images
           make api-server-push
           make api-server-with-data-push
+          make api-server-with-data-mt-push

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,8 @@
+# This avoids cross picking up custom linker from ~/.cargo/config.toml
+# See: https://github.com/cross-rs/cross/issues/621
+
+[build.env]
+passthrough = [
+    "CARGO_TARGET_X86_64_UNKNOWN_LINUX_GNU_LINKER=x86_64-linux-gnu-gcc",
+    "RUSTFLAGS",
+]

--- a/images/Makefile
+++ b/images/Makefile
@@ -3,6 +3,8 @@ KAMU_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | 
 API_SERVER_VERSION = $(shell cargo metadata --format-version 1 | jq -r '.packages[] | select( .name == "kamu-api-server") | .version')
 
 
+#########################################################################################
+
 .PHONY: api-server
 api-server:
 	docker build \
@@ -19,6 +21,8 @@ api-server-push:
 	docker push $(IMAGE_REPO)/kamu-api-server:latest
 
 
+#########################################################################################
+
 .PHONY: api-server-with-data
 api-server-with-data:
 	docker build \
@@ -31,3 +35,19 @@ api-server-with-data:
 .PHONY: api-server-with-data-push
 api-server-with-data-push:
 	docker push $(IMAGE_REPO)/kamu-api-server:latest-with-data
+
+
+#########################################################################################
+
+.PHONY: api-server-with-data-mt
+api-server-with-data-mt:
+	docker build \
+		--build-arg KAMU_VERSION=latest-with-data-mt \
+		--build-arg API_SERVER_VERSION=$(API_SERVER_VERSION) \
+		-t $(IMAGE_REPO)/kamu-api-server:latest-with-data-mt \
+		api-server-with-data-mt/
+
+
+.PHONY: api-server-with-data-mt-push
+api-server-with-data-mt-push:
+	docker push $(IMAGE_REPO)/kamu-api-server:latest-with-data-mt

--- a/images/api-server-with-data-mt/Dockerfile
+++ b/images/api-server-with-data-mt/Dockerfile
@@ -10,9 +10,10 @@ RUN wget -q https://github.com/kamu-data/kamu-platform/releases/download/v${API_
     mv kamu-api-server-x86_64-unknown-linux-gnu/kamu-api-server /opt/kamu/ && \
     rm -rf kamu-api-server-x86_64-unknown-linux-gnu*
 
+COPY config.yaml /opt/kamu/config.yaml
 
 ENTRYPOINT ["/usr/bin/tini", "--"]
 
-CMD ["/opt/kamu/kamu-api-server", "--repo-url=file:///opt/kamu/workspace/.kamu/datasets", "run", "--address=0.0.0.0", "--http-port=8080"]
+CMD [ "/opt/kamu/kamu-api-server", "--config=/opt/kamu/config.yaml", "--repo-url=file:///opt/kamu/workspace/.kamu/datasets", "--multi-tenant", "run", "--address=0.0.0.0", "--http-port=8080" ]
 
 EXPOSE 8080/tcp

--- a/images/api-server-with-data-mt/config.yaml
+++ b/images/api-server-with-data-mt/config.yaml
@@ -1,0 +1,81 @@
+auth:
+  providers:
+    # Dummy accounts for owners of example datasets
+    - kind: dummy
+      accounts:
+        - accountId: kamu
+          accountName: kamu
+          accountType: User
+          avatarUrl: https://avatars.githubusercontent.com/u/50896974?s=200&v=4
+          displayName: kamu
+        - accountId: sh101-bowen
+          accountName: sh101-bowen
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh101-bowen
+        - accountId: sh102-gambier
+          accountName: sh102-gambier
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh102-gambier
+        - accountId: sh103-howe
+          accountName: sh103-howe
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh103-howe
+        - accountId: sh104-granville
+          accountName: sh104-granville
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh104-granville
+        - accountId: sh105-keats
+          accountName: sh105-keats
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh105-keats
+        - accountId: sh106-seymour
+          accountName: sh106-seymour
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3118/3118054.png
+          displayName: sh106-seymour
+        - accountId: mim.dk
+          accountName: mim.dk
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3530/3530558.png
+          displayName: mim.dk
+        - accountId: mmo.gov.uk
+          accountName: mmo.gov.uk
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3530/3530558.png
+          displayName: mmo.gov.uk
+        - accountId: moa.gov.nl
+          accountName: moa.gov.nl
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3530/3530558.png
+          displayName: moa.gov.nl
+        - accountId: ofb.gouv.fr
+          accountName: ofb.gouv.fr
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3530/3530558.png
+          displayName: ofb.gouv.fr
+        - accountId: protectedseas.net
+          accountName: protectedseas.net
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/3530/3530558.png
+          displayName: protectedseas.net
+        - accountId: acme.fishing.co
+          accountName: acme.fishing.co
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/1090/1090630.png
+          displayName: ACME Fishing Company
+        - accountId: globalfishingwatch.org
+          accountName: globalfishingwatch.org
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/512/744/744480.png
+          displayName: globalfishingwatch.org
+        - accountId: bmis-bycatch.org
+          accountName: bmis-bycatch.org
+          accountType: User
+          avatarUrl: https://cdn-icons-png.flaticon.com/128/10197/10197245.png
+          displayName: Bycatch Management Information System
+    - kind: github

--- a/src/app/api-server/src/cli_parser.rs
+++ b/src/app/api-server/src/cli_parser.rs
@@ -33,6 +33,12 @@ pub fn cli() -> Command {
                 .long("repo-url")
                 .value_parser(value_parse_repo_url)
                 .help("URL of the remote dataset repository"),
+            // TODO: This is temporary and will be removed soon
+            // See: https://github.com/kamu-data/kamu-cli/issues/342
+            Arg::new("multi-tenant")
+                .long("multi-tenant")
+                .action(ArgAction::SetTrue)
+                .help("Indicates that target repo is multi-tenant (for file:// only)"),
         ])
         .subcommands([
             Command::new("run").about("Run the server").args([

--- a/src/app/api-server/tests/tests/test_di_graph.rs
+++ b/src/app/api-server/tests/tests/test_di_graph.rs
@@ -15,6 +15,7 @@ async fn test_di_graph_validates_local() {
     let mut catalog_builder = kamu_api_server::init_dependencies(
         kamu_api_server::config::ApiServerConfig::default(),
         &url::Url::from_directory_path(tempdir.path()).unwrap(),
+        false,
         tempdir.path(),
     )
     .await;
@@ -61,6 +62,7 @@ async fn test_di_graph_validates_remote() {
     let mut catalog_builder = kamu_api_server::init_dependencies(
         kamu_api_server::config::ApiServerConfig::default(),
         &repo_url,
+        true,
         tmp_repo_dir.path(),
     )
     .await;


### PR DESCRIPTION
Introduced an multi-tenant "with-data" image with dummy users in the config so not to cause resolution errors when querying for avatar and other account data.