### PR TITLE
Fix revert broken cc library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.20.2] - 2024-04-21
+## [0.20.3] - 2024-04-21
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1286,13 +1286,12 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.0.95"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32a725bc159af97c3e629873bb9f88fb8cf8a4867175f76dc987815ea07c83b"
+checksum = "17f6e324229dc011159fcc089755d1e2e216a90d43a7dea6853ca740b84f35e7"
 dependencies = [
  "jobserver",
  "libc",
- "once_cell",
 ]
 
 [[package]]


### PR DESCRIPTION
In last version of cc library where found a bug which causes fails during cross build https://github.com/rust-lang/cc-rs/issues/1039