### PR TITLE
Integrate OpenTelemetry and Prometheus

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2385,6 +2385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33480d6946193aa8033910124896ca395333cae7e2d1113d1fef6c3272217df2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-queue"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3638,16 +3647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "gethostname"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
-dependencies = [
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "getrandom"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3681,6 +3680,14 @@ name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
+
+[[package]]
+name = "graceful-shutdown"
+version = "0.28.3"
+dependencies = [
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "group"
@@ -4731,6 +4738,7 @@ dependencies = [
  "event-bus",
  "figment",
  "futures",
+ "graceful-shutdown",
  "http 0.2.12",
  "http-common",
  "hyper 0.14.30",
@@ -4757,6 +4765,7 @@ dependencies = [
  "kamu-flow-system-services",
  "kamu-task-system-inmem",
  "kamu-task-system-services",
+ "observability",
  "opendatafabric",
  "rand",
  "secrecy",
@@ -4773,8 +4782,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tracing",
- "tracing-bunyan-formatter",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "url",
 ]
@@ -5038,13 +5046,19 @@ version = "0.28.3"
 dependencies = [
  "alloy",
  "async-trait",
+ "axum",
  "ciborium",
  "clap",
  "confique",
+ "dill",
+ "graceful-shutdown",
  "hex",
  "http 0.2.12",
+ "hyper 0.14.30",
  "internal-error",
+ "observability",
  "opendatafabric",
+ "prometheus",
  "reqwest 0.12.5",
  "serde",
  "serde_json",
@@ -5053,7 +5067,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-log 0.2.0",
+ "tracing-log",
  "tracing-subscriber",
  "url",
 ]
@@ -5740,6 +5754,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "observability"
+version = "0.28.3"
+dependencies = [
+ "async-trait",
+ "axum",
+ "dill",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-otlp",
+ "opentelemetry-semantic-conventions",
+ "opentelemetry_sdk",
+ "prometheus",
+ "serde",
+ "serde_json",
+ "thiserror",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-appender",
+ "tracing-opentelemetry",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5788,10 +5826,90 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "opentelemetry"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b69a91d4893e713e06f724597ad630f1fa76057a5e1026c0ca67054a9032a76"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "js-sys",
+ "once_cell",
+ "pin-project-lite",
+ "thiserror",
+]
+
+[[package]]
+name = "opentelemetry-otlp"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a94c69209c05319cdf7460c6d4c055ed102be242a0a6245835d7bc42c6ec7f54"
+dependencies = [
+ "async-trait",
+ "futures-core",
+ "http 0.2.12",
+ "opentelemetry",
+ "opentelemetry-proto",
+ "opentelemetry_sdk",
+ "prost",
+ "thiserror",
+ "tokio",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "984806e6cf27f2b49282e2a05e288f30594f3dbc74eb7a6e99422bc48ed78162"
+dependencies = [
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "prost",
+ "tonic",
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cefe0543875379e47eb5f1e68ff83f45cc41366a92dfd0d073d513bf68e9a05"
+
+[[package]]
+name = "opentelemetry_sdk"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae312d58eaa90a82d2e627fd86e075cf5230b3f11794e2ed74199ebbe572d4fd"
+dependencies = [
+ "async-trait",
+ "futures-channel",
+ "futures-executor",
+ "futures-util",
+ "lazy_static",
+ "once_cell",
+ "opentelemetry",
+ "ordered-float 4.2.1",
+ "percent-encoding",
+ "rand",
+ "thiserror",
+ "tokio",
+ "tokio-stream",
+]
+
+[[package]]
 name = "ordered-float"
 version = "2.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68f19d67e5a2795c94e73e0bb1cc1a7edeb2e28efd39e2e1c9b7a40c1108b11c"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "ordered-float"
+version = "4.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ff2cf528c6c03d9ed653d6c4ce1dc0582dc4af309790ad92f07c1cd551b0be"
 dependencies = [
  "num-traits",
 ]
@@ -6373,6 +6491,20 @@ dependencies = [
  "syn 2.0.72",
  "version_check",
  "yansi 1.0.1",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror",
 ]
 
 [[package]]
@@ -8006,7 +8138,7 @@ checksum = "7e54bc85fc7faa8bc175c4bab5b92ba8d9a3ce893d0e9f42cc455c8ab16a9e09"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "ordered-float",
+ "ordered-float 2.10.1",
 ]
 
 [[package]]
@@ -8337,6 +8469,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tracing-appender"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
+dependencies = [
+ "crossbeam-channel",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tracing-attributes"
 version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8345,24 +8489,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.72",
-]
-
-[[package]]
-name = "tracing-bunyan-formatter"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5c266b9ac83dedf0e0385ad78514949e6d89491269e7065bee51d2bb8ec7373"
-dependencies = [
- "ahash",
- "gethostname",
- "log",
- "serde",
- "serde_json",
- "time",
- "tracing",
- "tracing-core",
- "tracing-log 0.1.4",
- "tracing-subscriber",
 ]
 
 [[package]]
@@ -8377,9 +8503,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-log"
-version = "0.1.4"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f751112709b4e791d8ce53e32c4ed2d353565a795ce84da2285393f41557bdf2"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
  "log",
  "once_cell",
@@ -8387,13 +8513,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-log"
-version = "0.2.0"
+name = "tracing-opentelemetry"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+checksum = "f68803492bf28ab40aeccaecc7021096bd256baf7ca77c3d425d89b35a7be4e4"
 dependencies = [
- "log",
+ "js-sys",
  "once_cell",
+ "opentelemetry",
+ "opentelemetry_sdk",
+ "tracing",
+ "tracing-core",
+ "tracing-subscriber",
+ "web-time",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc6b213177105856957181934e4920de57730fc69bf42c37ee5bb664d406d9e1"
+dependencies = [
+ "serde",
  "tracing-core",
 ]
 
@@ -8407,11 +8548,15 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex",
+ "serde",
+ "serde_json",
  "sharded-slab",
+ "smallvec",
  "thread_local",
  "tracing",
  "tracing-core",
- "tracing-log 0.2.0",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -8830,6 +8975,16 @@ name = "web-sys"
 version = "0.3.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,8 @@
 [workspace]
 members = [
     # Utils
+    "src/utils/graceful-shutdown",
+    "src/utils/observability",
     "src/utils/repo-tools",
     # Apps
     "src/app/api-server",
@@ -11,6 +13,9 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.28.2" }
+observability = { path = "src/utils/observability", version = "0.28.2" }
+# Utils (core)
 container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.191.4", version = "0.191.4", default-features = false }
 database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.191.4", version = "0.191.4", default-features = false }
 database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.191.4", version = "0.191.4", default-features = false }

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -17,8 +17,10 @@ publish = { workspace = true }
 dill = "0.8"
 container-runtime = { workspace = true }
 event-bus = { workspace = true }
+graceful-shutdown = { workspace = true }
 http-common = { workspace = true }
 internal-error = { workspace = true }
+observability = { workspace = true }
 opendatafabric = { workspace = true }
 database-common = { workspace = true }
 database-common-macros = { workspace = true }
@@ -69,7 +71,6 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
     "ansi",
 ] }
 tracing-log = "0.2"
-tracing-bunyan-formatter = "0.3"
 
 # Utils
 async-trait = { version = "0.1", default-features = false }
@@ -90,7 +91,10 @@ secrecy = "0.8"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tempfile = "3"
-tokio = { version = "1", default-features = false, features = ["macros"] }
+tokio = { version = "1", default-features = false, features = [
+    "macros",
+    "signal",
+] }
 tokio-stream = { version = "0.1", default-features = false, features = ["net"] }
 tokio-util = { version = "0.7", default-features = false, features = ["rt"] }
 thiserror = { version = "1", default-features = false }

--- a/src/app/api-server/src/main.rs
+++ b/src/app/api-server/src/main.rs
@@ -7,6 +7,10 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
+use internal_error::InternalError;
+
+/////////////////////////////////////////////////////////////////////////////////////////
+
 fn main() {
     let matches = kamu_api_server::cli().get_matches();
 
@@ -26,11 +30,22 @@ fn main() {
 
     let rt = builder.enable_all().build().unwrap();
 
-    match rt.block_on(kamu_api_server::run(matches, config)) {
+    match rt.block_on(main_async(matches, config)) {
         Ok(_) => {}
         Err(err) => {
             eprintln!("Error: {err}\nDetails: {err:#?}");
             std::process::exit(1)
         }
     }
+}
+
+async fn main_async(
+    args: clap::ArgMatches,
+    config: kamu_api_server::config::ApiServerConfig,
+) -> Result<(), InternalError> {
+    use kamu_api_server::app;
+
+    let _guard = app::init_observability();
+
+    kamu_api_server::app::run(args, config).await
 }

--- a/src/app/oracle-provider/Cargo.toml
+++ b/src/app/oracle-provider/Cargo.toml
@@ -14,7 +14,9 @@ publish = { workspace = true }
 
 
 [dependencies]
-opendatafabric = { workspace = true }
+graceful-shutdown = { workspace = true, default-features = false }
+observability = { workspace = true, default-features = false }
+opendatafabric = { workspace = true, default-features = false }
 
 alloy = { version = "0.2", default-features = false, features = [
     "std",
@@ -28,6 +30,10 @@ alloy = { version = "0.2", default-features = false, features = [
     "sol-types",
 ] }
 async-trait = { version = "0.1", default-features = false }
+axum = { version = "0.6", default-features = false, features = [
+    "http1",
+    "tokio",
+] }
 clap = { version = "4", default-features = false, features = [
     "std",
     "color",
@@ -42,9 +48,12 @@ clap = { version = "4", default-features = false, features = [
 ] }
 ciborium = { version = "0.2", default-features = false }
 confique = { version = "0.2", default-features = false, features = ["yaml"] }
+dill = { version = "0.8", default-features = false }
 hex = { version = "0.4" }
 http = { version = "0.2", default-features = false }
+hyper = { version = "0.14", default-features = false }
 internal-error = { workspace = true }
+prometheus = { version = "0.13", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
     "json",

--- a/src/app/oracle-provider/src/config.rs
+++ b/src/app/oracle-provider/src/config.rs
@@ -12,6 +12,14 @@ use url::Url;
 
 #[derive(confique::Config, Debug)]
 pub struct Config {
+    /// Interface to listen for HTTP admin traffic on
+    #[config(default = "127.0.0.1")]
+    pub http_address: String,
+
+    /// Port to listen for HTTP admin traffic on
+    #[config(default = 0)]
+    pub http_port: u16,
+
     /// Ethereum-compatible JSON-RPC address
     #[config(default = "http://localhost:8545")]
     pub rpc_url: Url,

--- a/src/app/oracle-provider/src/lib.rs
+++ b/src/app/oracle-provider/src/lib.rs
@@ -16,4 +16,4 @@ pub mod provider;
 
 pub use cli::Cli;
 pub use config::Config;
-pub use provider::OdfOracleProvider;
+pub use provider::{OdfOracleProvider, OdfOracleProviderMetrics};

--- a/src/app/oracle-provider/src/main.rs
+++ b/src/app/oracle-provider/src/main.rs
@@ -8,9 +8,10 @@
 // by the Apache License, Version 2.0.
 
 use clap::Parser;
+use internal_error::InternalError;
 use kamu_oracle_provider::{Cli, Config};
 
-const DEFAULT_RUST_LOG: &str = "RUST_LOG=debug,kamu=trace,hyper=info,h2=info";
+/////////////////////////////////////////////////////////////////////////////////////////
 
 fn main() {
     let args = Cli::parse();
@@ -21,14 +22,12 @@ fn main() {
         .load()
         .unwrap();
 
-    configure_tracing();
-
     let rt = tokio::runtime::Builder::new_multi_thread()
         .enable_all()
         .build()
         .unwrap();
 
-    match rt.block_on(kamu_oracle_provider::app::run(args, config)) {
+    match rt.block_on(main_async(args, config)) {
         Ok(_) => {}
         Err(err) => {
             tracing::error!(error = %err, error_dbg = ?err, "Provider exited with error");
@@ -37,24 +36,7 @@ fn main() {
     }
 }
 
-fn configure_tracing() {
-    use tracing_log::LogTracer;
-    use tracing_subscriber::fmt::format::FmtSpan;
-    use tracing_subscriber::layer::SubscriberExt;
-    use tracing_subscriber::util::SubscriberInitExt;
-    use tracing_subscriber::EnvFilter;
-
-    let env_filter = EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(DEFAULT_RUST_LOG));
-
-    tracing_subscriber::registry()
-        .with(env_filter)
-        .with(
-            tracing_subscriber::fmt::layer()
-                .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE)
-                .with_ansi(true),
-        )
-        .init();
-
-    // Redirect all standard logging to tracing events
-    LogTracer::init().expect("Failed to set LogTracer");
+async fn main_async(args: Cli, config: Config) -> Result<(), InternalError> {
+    let _guard = kamu_oracle_provider::app::init_observability();
+    kamu_oracle_provider::app::run(args, config).await
 }

--- a/src/app/oracle-provider/tests/tests/test_e2e.rs
+++ b/src/app/oracle-provider/tests/tests/test_e2e.rs
@@ -100,6 +100,8 @@ async fn test_oracle_e2e() {
         .unwrap();
 
     let config = provider::Config {
+        http_address: "127.0.0.1".into(),
+        http_port: 0,
         rpc_url: url::Url::parse(&anvil.endpoint()).unwrap(),
         chain_id: anvil.chain_id(),
         oracle_contract_address,
@@ -147,7 +149,12 @@ async fn test_oracle_e2e() {
     // Setup and run provider
     let rpc_client = provider::app::init_rpc_client(&config).await.unwrap();
     let api_client = Arc::new(MockOdfApiClient);
-    let provider = provider::OdfOracleProvider::new(config, rpc_client.clone(), api_client);
+    let provider = provider::OdfOracleProvider::new(
+        config,
+        rpc_client.clone(),
+        api_client,
+        provider::OdfOracleProviderMetrics::new(),
+    );
 
     provider.run_once(Some(0), None).await.unwrap();
 

--- a/src/utils/graceful-shutdown/Cargo.toml
+++ b/src/utils/graceful-shutdown/Cargo.toml
@@ -1,0 +1,26 @@
+[package]
+name = "graceful-shutdown"
+description = "Utilities for gracefully stoping the services"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+
+[dependencies]
+tracing = { version = "0.1", default-features = false }
+tokio = { version = "1", default-features = false, features = ["signal"] }

--- a/src/utils/graceful-shutdown/src/lib.rs
+++ b/src/utils/graceful-shutdown/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+/// Returns a future that completes when SIGINT or SIGTERM signal is received.
+/// Can be combined with facilities like Axum's [`with_graceful_shutdown`](https://docs.rs/axum/latest/axum/serve/struct.Serve.html#method.with_graceful_shutdown).
+pub async fn trap_signals() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("failed to install Ctrl+C handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("failed to install signal handler")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {
+            tracing::warn!("SIGINT signal received, shutting down gracefully");
+        },
+        _ = terminate => {
+            tracing::warn!("SIGTERM signal received, shutting down gracefully");
+        },
+    }
+}

--- a/src/utils/observability/Cargo.toml
+++ b/src/utils/observability/Cargo.toml
@@ -1,0 +1,54 @@
+[package]
+name = "observability"
+description = "Utilities for tracing and structured logging"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+
+[dependencies]
+async-trait = { version = "0.1" }
+axum = { version = "0.6", default-features = false, features = [
+    "json",
+    "matched-path",
+    "query",
+] }
+dill = { version = "0.8", default-features = false }
+http = { version = "0.2", default-features = false }
+opentelemetry = { version = "0.23", default-features = false }
+opentelemetry_sdk = { version = "0.23", default-features = false, features = [
+    "rt-tokio",
+] }
+opentelemetry-otlp = { version = "0.16", default-features = false, features = [
+    "trace",
+    "grpc-tonic",
+] }
+opentelemetry-semantic-conventions = { version = "0.16", default-features = false }
+prometheus = { version = "0.13", default-features = false }
+serde = { version = "1", default-features = false, features = ["derive"] }
+serde_json = { version = "1", default-features = false }
+thiserror = { version = "1", default-features = false }
+tracing = { version = "0.1", default-features = false }
+tracing-appender = { version = "0.2", default-features = false }
+tracing-opentelemetry = { version = "0.24", default-features = false }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tower = { version = "0.4", default-features = false }
+tower-http = { version = "0.4", default-features = false, features = ["trace"] }
+
+
+[dev-dependencies]

--- a/src/utils/observability/src/axum.rs
+++ b/src/utils/observability/src/axum.rs
@@ -1,0 +1,157 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use http::Uri;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub fn http_layer() -> tower_http::trace::TraceLayer<
+    tower_http::classify::SharedClassifier<tower_http::classify::ServerErrorsAsFailures>,
+    MakeSpan,
+    OnRequest,
+    OnResponse,
+> {
+    tower_http::trace::TraceLayer::new_for_http()
+        .on_request(OnRequest)
+        .on_response(OnResponse)
+        .make_span_with(MakeSpan)
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct OnRequest;
+
+impl<B> tower_http::trace::OnRequest<B> for OnRequest {
+    fn on_request(&mut self, request: &http::Request<B>, _: &tracing::Span) {
+        tracing::info!(
+            uri = %request.uri(),
+            version = ?request.version(),
+            headers = ?request.headers(),
+            "HTTP request",
+        );
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Debug)]
+pub struct OnResponse;
+
+impl<B> tower_http::trace::OnResponse<B> for OnResponse {
+    fn on_response(
+        self,
+        response: &http::Response<B>,
+        latency: std::time::Duration,
+        _span: &tracing::Span,
+    ) {
+        tracing::info!(
+            status = response.status().as_u16(),
+            headers = ?response.headers(),
+            latency = %Latency(latency),
+            "HTTP response"
+        );
+    }
+}
+
+struct Latency(std::time::Duration);
+
+impl std::fmt::Display for Latency {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} ms", self.0.as_millis())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct MakeSpan;
+
+impl<B> tower_http::trace::MakeSpan<B> for MakeSpan {
+    fn make_span(&mut self, request: &http::Request<B>) -> tracing::Span {
+        use opentelemetry::trace::TraceContextExt as _;
+        use tracing_opentelemetry::OpenTelemetrySpanExt as _;
+
+        // TODO: Extract parent context from the request
+
+        let method = request.method();
+        let route = RouteOrUri::from(request);
+
+        let span = tracing::info_span!(
+            "http_request",
+            %method,
+            %route,
+            // Placeholders for OTEL fileds that will be populated after span creation
+            trace_id = tracing::field::Empty,
+            "otel.name" = tracing::field::Empty,
+        );
+
+        // Extract trace ID from the OTEL context and add it to the tracing span
+        let context = span.context();
+        let otel_span = context.span();
+        let span_context = otel_span.span_context();
+        let trace_id = span_context.trace_id();
+        if span_context.is_valid() {
+            span.record("trace_id", tracing::field::display(trace_id));
+            span.record(
+                "otel.name",
+                tracing::field::display(SpanName::new(method, route)),
+            );
+        }
+
+        span
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct SpanName<'a> {
+    method: &'a http::Method,
+    route: RouteOrUri<'a>,
+}
+
+impl<'a> SpanName<'a> {
+    fn new(method: &'a http::Method, route: RouteOrUri<'a>) -> Self {
+        Self { method, route }
+    }
+}
+
+impl<'a> std::fmt::Display for SpanName<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{} {}", self.method, self.route)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+enum RouteOrUri<'a> {
+    Route(&'a str),
+    Uri(&'a Uri),
+}
+
+impl<'a, B> From<&'a http::Request<B>> for RouteOrUri<'a> {
+    fn from(request: &'a http::Request<B>) -> Self {
+        request
+            .extensions()
+            .get::<axum::extract::MatchedPath>()
+            .map_or_else(
+                || RouteOrUri::Uri(request.uri()),
+                |m| RouteOrUri::Route(m.as_str()),
+            )
+    }
+}
+
+impl<'a> std::fmt::Display for RouteOrUri<'a> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RouteOrUri::Route(s) => write!(f, "{s}"),
+            RouteOrUri::Uri(uri) => write!(f, "{uri}"),
+        }
+    }
+}

--- a/src/utils/observability/src/config.rs
+++ b/src/utils/observability/src/config.rs
@@ -1,0 +1,84 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+pub struct Config {
+    /// Name of the service that will appear e.g. in OTEL traces
+    pub service_name: String,
+    /// Version of the service that will appear e.g. in OTEL traces
+    pub service_version: String,
+    /// Log levels that will be used if `RUST_LOG` was not specified explicitly
+    pub default_log_levels: String,
+    /// OpenTelemetry protocol endpoint to export traces to
+    pub otlp_endpoint: Option<String>,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            service_name: "unnamed-service".to_string(),
+            service_version: "0.0.0".to_string(),
+            default_log_levels: "info".to_string(),
+            otlp_endpoint: None,
+        }
+    }
+}
+
+impl Config {
+    pub fn from_env() -> Self {
+        Self::from_env_with_prefix("")
+    }
+
+    pub fn from_env_with_prefix(prefix: &str) -> Self {
+        let mut cfg = Self::default();
+        if let Some(service_name) = std::env::var(format!("{prefix}SERVICE_NAME"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.service_name = service_name;
+        }
+        if let Some(service_version) = std::env::var(format!("{prefix}SERVICE_VERSION"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.service_version = service_version;
+        }
+        if let Some(otlp_endpoint) = std::env::var(format!("{prefix}OTLP_ENDPOINT"))
+            .ok()
+            .filter(|v| !v.is_empty())
+        {
+            cfg.otlp_endpoint = Some(otlp_endpoint);
+        }
+        cfg
+    }
+
+    pub fn with_service_name(mut self, service_name: impl Into<String>) -> Self {
+        self.service_name = service_name.into();
+        self
+    }
+
+    pub fn with_service_version(mut self, service_version: impl Into<String>) -> Self {
+        self.service_version = service_version.into();
+        self
+    }
+
+    pub fn with_default_log_levels(mut self, default_log_levels: impl Into<String>) -> Self {
+        self.default_log_levels = default_log_levels.into();
+        self
+    }
+
+    pub fn with_otlp_endpoint(mut self, otlp_endpoint: impl Into<String>) -> Self {
+        self.otlp_endpoint = Some(otlp_endpoint.into());
+        self
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/observability/src/health.rs
+++ b/src/utils/observability/src/health.rs
@@ -1,0 +1,79 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Type implementing this trait will be called during the health check
+/// procedure. Multiple checks can be added, in which case they will be called
+/// one by one with check considered failed upon the first error.
+#[async_trait::async_trait]
+pub trait HealthCheck: Send + Sync {
+    async fn check(&self, check_type: CheckType) -> Result<(), CheckError>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// Axum handler for serving the health checks. Depends on [`dill::Catalog`] to
+/// instantiate the implementations of the [`HealthCheck`] trait.
+pub async fn health_handler(
+    axum::Extension(catalog): axum::Extension<dill::Catalog>,
+    axum::extract::Query(args): axum::extract::Query<CheckArgs>,
+) -> Result<axum::Json<serde_json::Value>, CheckError> {
+    for checker in catalog.get::<dill::AllOf<dyn HealthCheck>>().unwrap() {
+        checker.check(args.r#type).await?;
+    }
+
+    Ok(axum::Json(serde_json::json!({
+        "ok": true,
+    })))
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, thiserror::Error)]
+#[error("{reason}")]
+pub struct CheckError {
+    pub reason: String,
+}
+
+impl axum::response::IntoResponse for CheckError {
+    fn into_response(self) -> axum::response::Response {
+        (
+            http::status::StatusCode::SERVICE_UNAVAILABLE,
+            axum::Json(serde_json::json!({
+                "ok": false,
+                "reason": self.reason,
+            })),
+        )
+            .into_response()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug, Default, serde::Deserialize, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum CheckType {
+    /// Determines when to restart the container
+    #[default]
+    Liveness,
+    /// Determines when to remove the instance from the loadbalancer
+    Readiness,
+    /// Is sent before liveness and readiness checks to determine when the
+    /// startup procedure is finished procedure is finished
+    Startup,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, serde::Deserialize)]
+pub struct CheckArgs {
+    #[serde(default)]
+    pub r#type: CheckType,
+}

--- a/src/utils/observability/src/init.rs
+++ b/src/utils/observability/src/init.rs
@@ -1,0 +1,157 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::io::IsTerminal;
+use std::time::Duration;
+
+use opentelemetry_otlp::WithExportConfig as _;
+use tracing_subscriber::fmt::format::FmtSpan;
+use tracing_subscriber::layer::SubscriberExt as _;
+use tracing_subscriber::util::SubscriberInitExt as _;
+use tracing_subscriber::EnvFilter;
+
+use super::config::Config;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// If application is started under a terminal will use the [`dev`] mode,
+/// otherwise will use [`service`] mode.
+pub fn auto(cfg: Config) -> Guard {
+    if std::io::stderr().is_terminal() {
+        dev(cfg)
+    } else {
+        service(cfg)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn dev(cfg: Config) -> Guard {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(cfg.default_log_levels.clone()));
+
+    let text_layer = tracing_subscriber::fmt::layer()
+        .pretty()
+        .with_writer(std::io::stderr)
+        .with_line_number(true)
+        .with_thread_names(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+
+    let (otel_layer, otlp_guard) = if cfg.otlp_endpoint.is_none() {
+        (None, None)
+    } else {
+        (
+            Some(
+                tracing_opentelemetry::layer()
+                    .with_error_records_to_exceptions(true)
+                    .with_tracer(init_otel_tracer(&cfg)),
+            ),
+            Some(OtlpGuard),
+        )
+    };
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer)
+        .with(text_layer)
+        .init();
+
+    Guard {
+        non_blocking_appender: None,
+        otlp_guard,
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[allow(clippy::needless_pass_by_value)]
+pub fn service(cfg: Config) -> Guard {
+    let env_filter =
+        EnvFilter::try_from_default_env().unwrap_or(EnvFilter::new(cfg.default_log_levels.clone()));
+
+    let (non_blocking, guard) = tracing_appender::non_blocking(std::io::stderr());
+
+    let text_layer = tracing_subscriber::fmt::layer()
+        .json()
+        .with_writer(non_blocking)
+        .with_line_number(true)
+        .with_thread_names(true)
+        .with_span_events(FmtSpan::NEW | FmtSpan::CLOSE);
+
+    let (otel_layer, otlp_guard) = if cfg.otlp_endpoint.is_none() {
+        (None, None)
+    } else {
+        (
+            Some(
+                tracing_opentelemetry::layer()
+                    .with_error_records_to_exceptions(true)
+                    .with_tracer(init_otel_tracer(&cfg)),
+            ),
+            Some(OtlpGuard),
+        )
+    };
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(otel_layer)
+        .with(text_layer)
+        .init();
+
+    Guard {
+        non_blocking_appender: Some(guard),
+        otlp_guard,
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+fn init_otel_tracer(cfg: &Config) -> opentelemetry_sdk::trace::Tracer {
+    use opentelemetry::KeyValue;
+    use opentelemetry_semantic_conventions::resource as otel_resource;
+
+    let otel_exporter = opentelemetry_otlp::new_exporter()
+        .tonic()
+        .with_endpoint(cfg.otlp_endpoint.as_ref().unwrap())
+        .with_timeout(Duration::from_secs(5));
+
+    opentelemetry_otlp::new_pipeline()
+        .tracing()
+        .with_exporter(otel_exporter)
+        .with_trace_config(
+            opentelemetry_sdk::trace::config()
+                .with_max_events_per_span(64)
+                .with_max_attributes_per_span(16)
+                .with_resource(opentelemetry_sdk::Resource::new([
+                    KeyValue::new(otel_resource::SERVICE_NAME, cfg.service_name.clone()),
+                    KeyValue::new(otel_resource::SERVICE_VERSION, cfg.service_version.clone()),
+                ]))
+                .with_sampler(opentelemetry_sdk::trace::Sampler::AlwaysOn),
+        )
+        .install_batch(opentelemetry_sdk::runtime::Tokio)
+        .expect("Creating tracer")
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[must_use]
+#[allow(dead_code)]
+#[derive(Default)]
+pub struct Guard {
+    pub non_blocking_appender: Option<tracing_appender::non_blocking::WorkerGuard>,
+    pub otlp_guard: Option<OtlpGuard>,
+}
+
+pub struct OtlpGuard;
+
+impl Drop for OtlpGuard {
+    fn drop(&mut self) {
+        opentelemetry::global::shutdown_tracer_provider();
+    }
+}

--- a/src/utils/observability/src/lib.rs
+++ b/src/utils/observability/src/lib.rs
@@ -7,16 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![feature(duration_constructors)]
-
-pub mod app;
-pub(crate) mod cli_parser;
+pub mod axum;
 pub mod config;
-pub(crate) mod database;
-pub(crate) mod flightsql_server;
-pub(crate) mod gql_server;
-pub(crate) mod http_server;
-
-pub use app::*;
-pub use cli_parser::*;
-pub(crate) use database::*;
+pub mod health;
+pub mod init;
+pub mod metrics;

--- a/src/utils/observability/src/metrics.rs
+++ b/src/utils/observability/src/metrics.rs
@@ -7,16 +7,17 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-#![feature(duration_constructors)]
+use prometheus::Encoder as _;
 
-pub mod app;
-pub(crate) mod cli_parser;
-pub mod config;
-pub(crate) mod database;
-pub(crate) mod flightsql_server;
-pub(crate) mod gql_server;
-pub(crate) mod http_server;
+#[allow(clippy::unused_async)]
+pub async fn metrics_handler(
+    axum::extract::Extension(reg): axum::extract::Extension<prometheus::Registry>,
+) -> String {
+    let mut buf = Vec::new();
 
-pub use app::*;
-pub use cli_parser::*;
-pub(crate) use database::*;
+    prometheus::TextEncoder::new()
+        .encode(&reg.gather(), &mut buf)
+        .unwrap();
+
+    String::from_utf8(buf).unwrap()
+}


### PR DESCRIPTION
**Two new util crates** are introduced:
- `observability` common things for logs, tracing, and metrics
- `graceful-shutdown` mini-crate for signal handling

**Graceful shutdown** was implemented for `api-server`. Currently only waits for pending HTTP requests to finish, not other protocols.

Bunyan **log format** was removed - instead the apps will **auto-detect the environment**:
- if `stderr` points to the TTY (developer mode) it will use pretty text format (see example below)
- otherwise will use `tracing`'s built-in json format:

**Better defaults for HTTP tracing** were configured, the example below shows span start/end (note method, route span fields) along with `HTTP request` and `HTTP response` events that include full URI, headers, and latency:

```
  2024-07-23T03:54:18.107150Z  INFO observability::axum: new
    at src/utils/observability/src/axum.rs:86 on tokio-runtime-worker
    in observability::axum::http_request with method: GET, route: /:account/:dataset

  2024-07-23T03:54:18.107294Z  INFO observability::axum: HTTP request, uri: /foo/bar?some=param, version: HTTP/1.1, headers: {"accept-encoding": "gzip, deflate, br", "user-agent": "xh/0.22.2", "connection": "keep-alive", "accept": "*/*", "host": "localhost:3003"}
    at src/utils/observability/src/axum.rs:33 on tokio-runtime-worker
    in observability::axum::http_request with method: GET, route: /:account/:dataset

  2024-07-23T03:54:18.107595Z  INFO observability::axum: HTTP response, status: 405, headers: {"content-length": "0", "access-control-allow-origin": "*", "vary": "origin", "vary": "access-control-request-method", "vary": "access-control-request-headers"}, latency: 0 ms
    at src/utils/observability/src/axum.rs:54 on tokio-runtime-worker
    in observability::axum::http_request with method: GET, route: /:account/:dataset

  2024-07-23T03:54:18.107806Z  INFO observability::axum: close, time.busy: 389µs, time.idle: 272µs
    at src/utils/observability/src/axum.rs:86 on tokio-runtime-worker
    in observability::axum::http_request with method: GET, route: /:account/:dataset

```

When `OTLP_ENDPOINT` env var is provided an **OpenTelemetry layer** will be configured:
- `trace_id` will appear in the root span allowing us to link logs to traces in Grafana
- Traces will be sent via `grpc` to the OTEL collector

New **system endpoints** are proposed:
- `/system/health?type={liveness,readiness,startup}` - using k8s semantics
- `/system/metrics` for Prometheus metrics

**Order of middlewares** was modified to have `/system/health` outside of tracing middleware not to produce too much spam.

**No-op health endpoints** were added to `api-server` and `oracle-provider` apps.

**Prometheus metrics** were added to `oracle-provider` app as a test of integration.