### PR TITLE
Release (minor) 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.33.0] - 2024-08-27
+### Changed
+- Upgrade kamu-cli version to `0.198.0` (address [RUSTSEC-2024-0363](https://rustsec.org/advisories/RUSTSEC-2024-0363))
+
 ## [0.32.1] - 2024-08-22
 ### Fixed
 - Add missed `ResetService` dependency
@@ -27,7 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.29.2] - 2024-07-30
 ### Changed
-- Upgrade kamu-cli version to 0.191.5 and add init of new DatasetKeyValueService in catalog 
+- Upgrade kamu-cli version to 0.191.5 and add init of new `DatasetKeyValueService` in catalog 
 
 ## [0.29.1] - 2024-07-23
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -139,9 +139,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.1.27"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b515e82c8468ddb6ff8db21c78a5997442f113fd8471fd5b2261b2602dd0c67"
+checksum = "bb07629a5d0645d29f68d2fb6f4d0cf15c89ec0965be915f303967180929743f"
 dependencies = [
  "num_enum",
  "strum 0.26.3",
@@ -409,7 +409,7 @@ checksum = "4d0f2d905ebd295e7effec65e5f6868d153936130ae718352771de3e7d03c75c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -529,7 +529,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -546,7 +546,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "syn-solidity",
  "tiny-keccak",
 ]
@@ -564,7 +564,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "serde_json",
- "syn 2.0.75",
+ "syn 2.0.76",
  "syn-solidity",
 ]
 
@@ -1228,7 +1228,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strum 0.25.0",
- "syn 2.0.75",
+ "syn 2.0.76",
  "thiserror",
 ]
 
@@ -1264,7 +1264,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1286,7 +1286,7 @@ checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1297,7 +1297,7 @@ checksum = "6e0c28dcc82d7c8ead5cb13beb15405b57b8546e93215673ff8ca0349a028107"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1343,7 +1343,7 @@ checksum = "3c87f3f15e7794432337fc718554eaa4dc8f04c9677a950ffe366f20a162ae42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -1961,7 +1961,7 @@ dependencies = [
  "arrayvec",
  "cc",
  "cfg-if",
- "constant_time_eq 0.3.0",
+ "constant_time_eq 0.3.1",
 ]
 
 [[package]]
@@ -2078,23 +2078,24 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf100c4cea8f207e883ff91ca886d621d8a166cb04971dfaa9bb8fd99ed95df"
+checksum = "f0307f72feab3300336fb803a57134159f6e20139af1357f36c54cb90d8e8928"
 dependencies = [
  "blst",
  "cc",
  "glob",
  "hex",
  "libc",
+ "once_cell",
  "serde",
 ]
 
 [[package]]
 name = "cc"
-version = "1.1.13"
+version = "1.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
+checksum = "57b6a275aa2903740dc87da01c62040406b8812552e97129a63ea8850a17c6e6"
 dependencies = [
  "jobserver",
  "libc",
@@ -2213,7 +2214,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2318,14 +2319,14 @@ checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "constant_time_eq"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7144d30dcf0fafbce74250a3963025d8d52177934239851c917d29f1df280c2"
+checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2535,7 +2536,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2559,7 +2560,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2570,7 +2571,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -2608,8 +2609,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2633,11 +2634,11 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3042,7 +3043,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version 0.4.0",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3097,7 +3098,7 @@ checksum = "9d0e68e1e07d64dbf3bb2991657979ec4e3fe13b7b3c18067b802052af1330a3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3280,13 +3281,13 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "enum-variants"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 
 [[package]]
 name = "env_filter"
@@ -3351,8 +3352,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3366,11 +3367,11 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3384,9 +3385,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fc0510504f03c51ada170672ac806f1f105a88aa97a5281117e1ddc3368e51a"
+checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
 
 [[package]]
 name = "fastrlp"
@@ -3482,9 +3483,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.32"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c0596c1eac1f9e04ed902702e9878208b336edc9d6fddc8a48387349bab3666"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
  "miniz_oxide 0.8.0",
@@ -3604,7 +3605,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -3715,7 +3716,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graceful-shutdown"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -3999,8 +4000,8 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "axum",
  "http 0.2.12",
@@ -4283,8 +4284,8 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "thiserror",
 ]
@@ -4405,8 +4406,8 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-recursion",
  "async-stream",
@@ -4476,8 +4477,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "base32",
@@ -4503,8 +4504,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4520,8 +4521,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4538,8 +4539,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4563,8 +4564,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4581,8 +4582,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "dill",
@@ -4597,8 +4598,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4615,8 +4616,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -4650,8 +4651,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -4694,8 +4695,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4712,8 +4713,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "axum",
  "chrono",
@@ -4736,7 +4737,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -4813,8 +4814,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4844,8 +4845,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -4866,8 +4867,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -4886,8 +4887,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4905,8 +4906,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4924,8 +4925,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4946,8 +4947,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4965,8 +4966,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4991,8 +4992,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5013,8 +5014,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5031,14 +5032,13 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
  "database-common",
- "database-common-macros",
  "dill",
  "futures",
  "internal-error",
@@ -5061,8 +5061,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5079,8 +5079,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5109,8 +5109,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5125,8 +5125,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5144,8 +5144,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5162,7 +5162,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-oracle-provider"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5194,7 +5194,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5207,8 +5207,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5224,8 +5224,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5237,8 +5237,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5402,9 +5402,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.28.0"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c10584274047cb335c23d3e61bcef8e323adae7c5c8c760540f73610177fc3f"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
 dependencies = [
  "cc",
  "pkg-config",
@@ -5572,8 +5572,8 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5690,8 +5690,8 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "bs58",
  "digest 0.10.7",
@@ -5869,7 +5869,7 @@ checksum = "af1844ef2428cc3e1cb900be36181049ef3d3193c63e43026cfe202983b27a56"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -5913,7 +5913,7 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.32.1"
+version = "0.33.0"
 dependencies = [
  "async-trait",
  "axum",
@@ -5949,8 +5949,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -6140,7 +6140,7 @@ version = "3.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d830939c76d294956402033aee57a6da7b438f2294eb94864c37b0569053a42c"
 dependencies = [
- "proc-macro-crate 3.1.0",
+ "proc-macro-crate 3.2.0",
  "proc-macro2",
  "quote",
  "syn 1.0.109",
@@ -6286,7 +6286,7 @@ dependencies = [
  "proc-macro2",
  "proc-macro2-diagnostics",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -6345,7 +6345,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -6443,7 +6443,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -6607,11 +6607,11 @@ dependencies = [
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d37c51ca738a55da99dc0c4a34860fd675453b8b36209178c2249bb13651284"
+checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
 dependencies = [
- "toml_edit 0.21.1",
+ "toml_edit 0.22.20",
 ]
 
 [[package]]
@@ -6655,7 +6655,7 @@ checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "version_check",
  "yansi 1.0.1",
 ]
@@ -6714,7 +6714,7 @@ dependencies = [
  "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -6792,9 +6792,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -6846,8 +6846,8 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "rand",
 ]
@@ -7213,7 +7213,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.6",
+ "rustls-webpki 0.102.7",
  "subtle",
  "zeroize",
 ]
@@ -7280,9 +7280,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.6"
+version = "0.102.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e6b52d4fda176fd835fdc55a835d4a89b8499cad995885a21149d5ad62f852e"
+checksum = "84678086bd54edf2b415183ed7a94d0efb049f1b646a33e22a36f3794be6ae56"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -7445,29 +7445,29 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
+checksum = "99fce0ffe7310761ca6bf9faf5115afbc19688edd00171d81b1bb1b116c63e09"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.208"
+version = "1.0.209"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
+checksum = "a5831b979fd7b5439637af1752d535ff49f4860c0f341d1baeb6faf0f4242170"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.125"
+version = "1.0.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
+checksum = "8043c06d9f82bd7271361ed64f415fe5e12a77fdb52e573e7f06a516dea329ad"
 dependencies = [
  "itoa",
  "memchr",
@@ -7533,7 +7533,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -7777,14 +7777,14 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "sqlx"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27144619c6e5802f1380337a209d2ac1c431002dd74c6e60aebff3c506dc4f0c"
+checksum = "fcfa89bea9500db4a0d038513d7a060566bfc51d46d1c014847049a45cce85e8"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -7795,9 +7795,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a999083c1af5b5d6c071d34a708a19ba3e02106ad82ef7bbd69f5e48266b613b"
+checksum = "d06e2f2bd861719b1f3f0c7dbe1d80c30bf59e76cf019f07d9014ed7eefb8e08"
 dependencies = [
  "atoi",
  "byteorder",
@@ -7821,8 +7821,8 @@ dependencies = [
  "once_cell",
  "paste",
  "percent-encoding",
- "rustls 0.21.12",
- "rustls-pemfile 1.0.4",
+ "rustls 0.23.12",
+ "rustls-pemfile 2.1.3",
  "serde",
  "serde_json",
  "sha2",
@@ -7834,27 +7834,27 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
- "webpki-roots 0.25.4",
+ "webpki-roots 0.26.3",
 ]
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23217eb7d86c584b8cbe0337b9eacf12ab76fe7673c513141ec42565698bb88"
+checksum = "2f998a9defdbd48ed005a89362bd40dd2117502f15294f61c8d47034107dbbdc"
 dependencies = [
  "proc-macro2",
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a099220ae541c5db479c6424bdf1b200987934033c2584f79a0e1693601e776"
+checksum = "3d100558134176a2629d46cec0c8891ba0be8910f7896abfdb75ef4ab6f4e7ce"
 dependencies = [
  "dotenvy",
  "either",
@@ -7870,7 +7870,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.75",
+ "syn 2.0.76",
  "tempfile",
  "tokio",
  "url",
@@ -7878,9 +7878,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5afe4c38a9b417b6a9a5eeffe7235d0a106716495536e7727d1c7f4b1ff3eba6"
+checksum = "936cac0ab331b14cb3921c62156d913e4c15b74fb6ec0f3146bd4ef6e4fb3c12"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -7922,9 +7922,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1dbb157e65f10dbe01f729339c06d239120221c9ad9fa0ba8408c4cc18ecf21"
+checksum = "9734dbce698c67ecf67c442f768a5e90a49b2a4d61a9f1d59f73874bd4cf0710"
 dependencies = [
  "atoi",
  "base64 0.22.1",
@@ -7962,9 +7962,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b2cdd83c008a622d94499c0006d8ee5f821f36c89b7d625c900e5dc30b5c5ee"
+checksum = "a75b419c3c1b1697833dd927bdc4c6545a620bc1bbafabd44e1efbe9afcd337e"
 dependencies = [
  "atoi",
  "chrono",
@@ -8062,7 +8062,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8075,7 +8075,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8097,9 +8097,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.75"
+version = "2.0.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
+checksum = "578e081a14e0cefc3279b0472138c513f37b41a08d5a3cca9b6e4e8ceb6cd525"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -8115,7 +8115,7 @@ dependencies = [
  "paste",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8221,7 +8221,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "sha2",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8243,7 +8243,7 @@ checksum = "5999e24eaa32083191ba4e425deb75cdf25efefabe5aaccb7446dd0d4122a3f5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8263,7 +8263,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8329,8 +8329,8 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.197.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.197.0#3009ff0ad832ad7f0982da25043bb0d8e9539d4a"
+version = "0.198.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.198.0#81f23277545cef316d7e03e628f4073c138f8449"
 dependencies = [
  "async-trait",
  "chrono",
@@ -8398,7 +8398,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -8507,17 +8507,6 @@ name = "toml_edit"
 version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap 2.4.0",
- "toml_datetime",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
-version = "0.21.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8534fd7f78b5405e860340ad6575217ce99f38d4d5c8f2442cb5ecb50090e1"
 dependencies = [
  "indexmap 2.4.0",
  "toml_datetime",
@@ -8653,7 +8642,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9078,7 +9067,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-shared",
 ]
 
@@ -9112,7 +9101,7 @@ checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -9517,7 +9506,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]
@@ -9537,7 +9526,7 @@ checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.75",
+ "syn 2.0.76",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,51 +13,51 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.32.1", default-features = false }
-observability = { path = "src/utils/observability", version = "0.32.1", default-features = false }
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.33.0", default-features = false }
+observability = { path = "src/utils/observability", version = "0.33.0", default-features = false }
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-random-names = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+random-names = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
 # Domain
-opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
+opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-auth-oso = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.197.0", version = "0.197.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-auth-oso = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.198.0", version = "0.198.0", default-features = false }
 
 
 [workspace.package]
-version = "0.32.1"
+version = "0.33.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu Platform Version 0.32.1
+Licensed Work:             Kamu Platform Version 0.33.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2028-08-22
+Change Date:               2028-08-27
 
 Change License:            Apache License, Version 2.0
 

--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,2 @@
+unreadable-literal-lint-fractions = false
+disallowed-macros = ["std::dbg"]

--- a/deny.toml
+++ b/deny.toml
@@ -18,7 +18,6 @@ deny = [
     ### Crates we shouldn't use ####
     # "Configure `rustls` instead"
     { name = "openssl-sys" },
-
     # Use `md-5` instead, which is part of the RustCrypto ecosystem
     { name = "md5" },
     # TODO: We should decide whether to stick with rustls or openssl and deny one of them
@@ -82,6 +81,4 @@ allow-org = { github = ["kamu-data", "apache"] }
 yanked = "deny"
 # TODO: Remove when patches are available
 #       See more: https://rustsec.org/advisories/RUSTSEC-2023-0071.html
-# TODO: Remove when patch will be released
-#       See more: https://github.com/launchbadge/sqlx/issues/3440
-ignore = ["RUSTSEC-2023-0071", "RUSTSEC-2024-0363"]
+ignore = ["RUSTSEC-2023-0071"]


### PR DESCRIPTION
### Changed
- Upgrade kamu-cli version to `0.198.0` (address [RUSTSEC-2024-0363](https://rustsec.org/advisories/RUSTSEC-2024-0363))