### PR TITLE
Release (patch): 0.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.41.1] - 2024-10-24
+### Changed
+- Upgrade kamu-cli version to `0.206.1`:
+  - `DatasetEntryIndexer`: guarantee startup after `OutboxExecutor` for a more predictable initialization 
+    - Add `DatasetEntry`'is re-indexing migration
+
 ## [0.41.0] - 2024-10-23
 ### Added
 - Introduced OpenAPI spec generation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2420,8 +2420,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2715,8 +2715,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -2740,8 +2740,8 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "quote",
  "syn 2.0.83",
@@ -3525,8 +3525,8 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 
 [[package]]
 name = "env_filter"
@@ -3591,8 +3591,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3606,8 +3606,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "quote",
  "syn 2.0.83",
@@ -3958,7 +3958,7 @@ checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
 name = "graceful-shutdown"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "tokio",
  "tracing",
@@ -4255,8 +4255,8 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "axum",
  "http 1.1.0",
@@ -4508,8 +4508,8 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "init-on-startup"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "database-common",
@@ -4555,8 +4555,8 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "thiserror",
 ]
@@ -4682,8 +4682,8 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -4760,8 +4760,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "base32",
@@ -4787,8 +4787,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4804,8 +4804,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4822,8 +4822,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "argon2",
  "async-trait",
@@ -4848,8 +4848,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -4866,8 +4866,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "dill",
@@ -4883,8 +4883,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -4901,8 +4901,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -4936,8 +4936,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -4986,8 +4986,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5004,8 +5004,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "axum",
  "chrono",
@@ -5030,7 +5030,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "arrow-flight",
  "async-graphql",
@@ -5121,8 +5121,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5134,8 +5134,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "dill",
@@ -5145,8 +5145,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5159,8 +5159,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "dill",
@@ -5175,8 +5175,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5189,8 +5189,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5220,8 +5220,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-data-utils"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -5242,8 +5242,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5262,8 +5262,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5281,8 +5281,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5300,8 +5300,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5327,8 +5327,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5346,8 +5346,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5375,8 +5375,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5399,8 +5399,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5418,8 +5418,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5450,8 +5450,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5469,8 +5469,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5498,8 +5498,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5514,8 +5514,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5533,8 +5533,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5551,7 +5551,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-oracle-provider"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5586,7 +5586,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.41.0"
+version = "0.41.1"
 dependencies = [
  "chrono",
  "clap",
@@ -5599,8 +5599,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5618,8 +5618,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5632,8 +5632,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5650,8 +5650,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5675,8 +5675,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6064,8 +6064,8 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6175,8 +6175,8 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6393,8 +6393,8 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "axum",
@@ -6443,8 +6443,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7374,8 +7374,8 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "rand",
 ]
@@ -8856,8 +8856,8 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.206.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.0#c42de0e81c239c7848e1281b5472937af01f7e4d"
+version = "0.206.1"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.206.1#380c944f04ac199b9974903c926dbe9b0354bed5"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,59 +12,59 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.41.0", default-features = false }
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.41.1", default-features = false }
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-random-names = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+random-names = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
 # Domain
-opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
+opendatafabric = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-auth-oso = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
-kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.0", version = "0.206.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-auth-oso = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
+kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.206.1", version = "0.206.1", default-features = false }
 
 
 [workspace.package]
-version = "0.41.0"
+version = "0.41.1"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu Platform Version 0.41.0
+Licensed Work:             Kamu Platform Version 0.41.1
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -840,7 +840,7 @@
       "name": ""
     },
     "title": "kamu-api-server",
-    "version": "0.41.0"
+    "version": "0.41.1"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -840,7 +840,7 @@
       "name": ""
     },
     "title": "kamu-api-server",
-    "version": "0.41.0"
+    "version": "0.41.1"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
### Changed
- Upgrade kamu-cli version to `0.206.1`:
  - https://github.com/kamu-data/kamu-cli/pull/923
  - `DatasetEntryIndexer`: guarantee startup after `OutboxExecutor` for a more predictable initialization 
    - Add `DatasetEntry`'is re-indexing migration