### PR TITLE
Feature/email gateway

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
    - Config support for gateway settings (API key, sender address & name)
    - Applied `askoma` templating engine and defined base HTML-rich template for all emails
    - Emails are fire-and-forget / best effort
-   - First email implemented: account registration
+   - First emails implemented: account registration, flow failed
 - GQL suport to query and update email on the currently logged account
 ### Changed
 - Emails are mandatory for Kamu accounts now:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.53.0] - 2025-01-30
+### Added
+- Integration of email gateway (Postmark):
+   - Defined `EmailSender` crate and prototyped `Postmark`-based implementation
+   - Config support for gateway settings (API key, sender address & name)
+   - Applied `askoma` templating engine and defined base HTML-rich template for all emails
+   - Emails are fire-and-forget / best effort
+   - First email implemented: account registration
+- GQL suport to query and update email on the currently logged account
+### Changed
+- Emails are mandatory for Kamu accounts now:
+   - predefined users need to specify an email in config
+   - predefined users are auto-synced at startup in case they existed before
+   - GitHub users are queried for primary verified email, even if it is not public
+   - migration code for the database existing users
+
 ## [0.52.1] - 2025-01-29
 ### Fixed
 - Corrected access rights checks for transport protocols (SiTP, SmTP)
-
-## [0.52.0] - 2025-01-28
-### Changed
-- Core changes from the Private Datasets epic (kamu CLI `0.220.0`), Vol. 2
-
-## [0.51.0] - 2025-01-20
-### Changed
-- Toolchain updated to `nightly-2024-12-26`
-- Core changes from the Private Datasets epic (kamu CLI `0.219.1`)
-
-## [0.50.4] - 2024-01-15
-### Fixed
-- Telemetry-driven fixes in flow listings (kamu CLI `0.217.3`)
-
 ## [0.50.3] - 2024-01-13
 ### Changed
 - Batched loading of flows and tasks (kamu CLI `0.217.2`)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1240,6 +1240,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71938f30533e4d95a6d17aa530939da3842c2ab6f4f84b9dae68447e4129f74a"
 
 [[package]]
+name = "askama"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b79091df18a97caea757e28cd2d5fda49c6cd4bd01ddffd7ff01ace0c0ad2c28"
+dependencies = [
+ "askama_derive",
+ "askama_escape",
+ "humansize",
+ "num-traits",
+ "percent-encoding",
+]
+
+[[package]]
+name = "askama_derive"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19fe8d6cb13c4714962c072ea496f3392015f0989b1a2847bb4b2d9effd71d83"
+dependencies = [
+ "askama_parser",
+ "basic-toml",
+ "mime",
+ "mime_guess",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "askama_escape"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
+
+[[package]]
+name = "askama_parser"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acb1161c6b64d1c3d83108213c2a2533a342ac225aabd0bda218278c2ddb00c0"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1393,8 +1437,8 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "tokio",
@@ -1996,6 +2040,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
 
 [[package]]
+name = "basic-toml"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "823388e228f614e9558c6804262db37960ec8821856535f5c3f59913140558f8"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bigdecimal"
 version = "0.4.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,8 +2524,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -2776,8 +2829,8 @@ checksum = "e8566979429cf69b49a5c740c60791108e86440e8be149bbea4fe54d2c32d6e2"
 
 [[package]]
 name = "database-common"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -2802,8 +2855,8 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -3554,6 +3607,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "email-gateway"
+version = "0.53.0"
+dependencies = [
+ "async-trait",
+ "dill",
+ "email-utils",
+ "internal-error",
+ "reqwest",
+ "secrecy",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.11",
+ "tracing",
+]
+
+[[package]]
+name = "email-utils"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
+dependencies = [
+ "serde",
+ "thiserror 2.0.11",
+ "validator",
+]
+
+[[package]]
 name = "ena"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3594,8 +3673,8 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 
 [[package]]
 name = "env_filter"
@@ -3658,8 +3737,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3672,8 +3751,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "quote",
  "syn 2.0.96",
@@ -3759,8 +3838,8 @@ dependencies = [
 
 [[package]]
 name = "file-utils"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 
 [[package]]
 name = "filetime"
@@ -4046,7 +4125,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graceful-shutdown"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -4415,8 +4494,8 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "axum",
  "http 1.2.0",
@@ -4446,6 +4525,15 @@ name = "httpdate"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
+name = "humansize"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6cb51c9a029ddc91b07a787f1d86b53ccfa49b0e86688c946ebe8d3555685dd7"
+dependencies = [
+ "libm",
+]
 
 [[package]]
 name = "humantime"
@@ -4789,8 +4877,8 @@ checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
 
 [[package]]
 name = "init-on-startup"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -4824,8 +4912,8 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "thiserror 2.0.11",
 ]
@@ -4962,8 +5050,8 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5037,19 +5125,21 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "base32",
  "chrono",
  "crc32fast",
  "database-common",
+ "email-utils",
  "futures",
  "internal-error",
  "jsonwebtoken",
  "lazy_static",
  "merge",
+ "messaging-outbox",
  "mockall",
  "opendatafabric",
  "rand",
@@ -5064,13 +5154,14 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
  "database-common",
  "dill",
+ "email-utils",
  "futures",
  "internal-error",
  "kamu-accounts",
@@ -5080,14 +5171,15 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
  "database-common",
  "dill",
+ "email-utils",
  "futures",
  "internal-error",
  "kamu-accounts",
@@ -5099,8 +5191,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5112,6 +5204,7 @@ dependencies = [
  "internal-error",
  "jsonwebtoken",
  "kamu-accounts",
+ "messaging-outbox",
  "opendatafabric",
  "password-hash",
  "serde",
@@ -5124,14 +5217,15 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
  "chrono",
  "database-common",
  "dill",
+ "email-utils",
  "futures",
  "internal-error",
  "kamu-accounts",
@@ -5143,8 +5237,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5167,8 +5261,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5196,8 +5290,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5205,6 +5299,7 @@ dependencies = [
  "database-common",
  "datafusion",
  "dill",
+ "email-utils",
  "event-sourcing",
  "futures",
  "internal-error",
@@ -5228,8 +5323,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5244,6 +5339,7 @@ dependencies = [
  "datafusion",
  "dill",
  "ed25519-dalek",
+ "email-utils",
  "flate2",
  "futures",
  "headers",
@@ -5278,11 +5374,12 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "dill",
+ "email-utils",
  "http 1.2.0",
  "internal-error",
  "kamu-accounts",
@@ -5295,8 +5392,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "axum",
  "chrono",
@@ -5318,11 +5415,13 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "arrow-flight",
+ "askama",
  "async-graphql",
  "async-graphql-axum",
+ "async-trait",
  "axum",
  "chrono",
  "clap",
@@ -5331,6 +5430,8 @@ dependencies = [
  "database-common-macros",
  "dill",
  "duration-string",
+ "email-gateway",
+ "email-utils",
  "figment",
  "futures",
  "graceful-shutdown",
@@ -5400,8 +5501,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5413,8 +5514,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "dill",
@@ -5424,8 +5525,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5437,8 +5538,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5458,8 +5559,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5471,8 +5572,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5504,8 +5605,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5526,8 +5627,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5543,8 +5644,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5560,8 +5661,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5588,8 +5689,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5605,8 +5706,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5631,8 +5732,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5649,8 +5750,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5667,8 +5768,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5694,8 +5795,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5712,8 +5813,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5738,8 +5839,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "dill",
@@ -5751,8 +5852,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5766,8 +5867,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5782,7 +5883,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-oracle-provider"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5814,7 +5915,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.52.1"
+version = "0.53.0"
 dependencies = [
  "chrono",
  "clap",
@@ -5829,8 +5930,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5849,8 +5950,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5862,8 +5963,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5878,8 +5979,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5902,8 +6003,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6303,8 +6404,8 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6342,6 +6443,12 @@ dependencies = [
  "mime",
  "unicase",
 ]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
@@ -6408,8 +6515,8 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -6439,6 +6546,16 @@ name = "new_debug_unreachable"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
 
 [[package]]
 name = "nu-ansi-term"
@@ -6631,8 +6748,8 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "axum",
@@ -6681,8 +6798,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -6697,8 +6814,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -6719,8 +6836,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6742,8 +6859,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6774,8 +6891,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -6805,8 +6922,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -6824,8 +6941,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -6843,8 +6960,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -6859,8 +6976,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -6878,8 +6995,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7885,8 +8002,8 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "rand",
 ]
@@ -8356,8 +8473,8 @@ checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "s3-utils"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -9304,8 +9421,8 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "axum",
  "container-runtime",
@@ -9420,8 +9537,8 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.220.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.220.0#693095657b539f8636e74b445eb5032eb03d1768"
+version = "0.221.0"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.221.0#eb07ada18d785fc5e1975ec0d915aa9878ea3a0c"
 dependencies = [
  "async-trait",
  "chrono",
@@ -10087,6 +10204,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b913a3b5fe84142e269d63cc62b64319ccaf89b748fc31fe025177f767a756c4"
 dependencies = [
  "getrandom",
+]
+
+[[package]]
+name = "validator"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43fb22e1a008ece370ce08a3e9e4447a910e92621bb49b85d6e48a45397e7cfa"
+dependencies = [
+ "idna",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 members = [
     # Utils
+    "src/utils/email-gateway",
     "src/utils/graceful-shutdown",
     "src/utils/repo-tools",
     # Apps
@@ -12,67 +13,67 @@ resolver = "2"
 
 [workspace.dependencies]
 # Utils
-graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.52.1", default-features = false }
+email-gateway = { path = "src/utils/email-gateway", version = "0.53.0", default-features = false, features = ["postmark"] }
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.53.0", default-features = false }
 
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-s3-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-test-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+email-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+s3-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+test-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
 
 ## Open Data Fabric
-odf = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false, package = "opendatafabric" }
+odf = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false, package = "opendatafabric" }
 
 # Domain
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-
-# Adapter
-kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
 
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
-kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.220.0", version = "0.220.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
+kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.221.0", version = "0.221.0", default-features = false }
 
 
 [workspace.package]
-version = "0.52.1"
+version = "0.53.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu Platform Version 0.52.1
+Licensed Work:             Kamu Platform Version 0.53.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2029-01-28
+Change Date:               2029-01-30
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/email-templates/account-registered.html
+++ b/resources/email-templates/account-registered.html
@@ -1,0 +1,9 @@
+{% extends "base.html" %}
+
+{% block title %}Welcome to Kamu!{% endblock %}
+
+{% block header %}Welcome, {{ username }}!{% endblock %}
+
+{% block content %}
+<p>Thank you for registering with Kamu. We're thrilled to have you on board!</p>
+{% endblock %}

--- a/resources/email-templates/base.html
+++ b/resources/email-templates/base.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html
+    PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en-GB">
+
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>{% block title %}Default Title{% endblock %}</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta itemprop="image" content="https://www.kamu.dev/images/social/card.png" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" />
+
+    <style type="text/css">
+        a[x-apple-data-detectors] {
+            color: inherit !important;
+        }
+
+        a {
+            color: #1661b7;
+        }
+
+        * {
+            font-family: Muller, Arial, Helvetica, sans-serif;
+            font-style: normal;
+            font-weight: normal;
+            font-size: 16px;
+            line-height: 150%;
+            color: #373a3c;
+        }
+
+        b {
+            font-style: normal;
+            font-weight: bold;
+            font-size: 18px;
+            line-height: 150%;
+            color: #373a3c;
+        }
+
+        .header {
+            font-style: normal;
+            font-weight: bold;
+            font-size: 18px;        
+            padding: 0 10px;
+            text-align: center;
+        }
+        
+        .code {
+            background-color: #f4f4f4;
+            font-family: monospace;
+        }             
+
+    </style>
+    {% block extrastyles %}{% endblock %}
+</head>
+
+<body style="margin: 0; padding: 0">
+    <table role="presentation" border="0" cellpadding="0" cellspacing="0" width="100%">
+        <tr>
+            <td style="padding: 20px">
+                <table align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; min-width: 400px; max-width: 700px;">
+                    <tr>
+                        <td align="center">
+                            <img src="https://docs.kamu.dev/images/kamu-logo-slogan.png" alt="Kamu Logo" height="66" style="display: block; padding-top: 16px; padding-bottom: 16px;" />
+                        </td>
+                    </tr>
+
+                    <tr style="margin-top: 40px; display: block">
+                        <td align="left">
+                            <div class="header">
+                                {% block header %}Default Header{% endblock %}
+                            </div>
+
+                            {% block content %}Default Content{% endblock %}
+
+                            <p>If you have any questions, feel free to contact us at <a href="mailto:support@kamu.dev">support@kamu.dev</a>.</p>
+
+                            <p>Thank you,<br />The Kamu Team</p>
+                            <a align="right" href="https://www.kamu.dev/">Visit Kamu</a>
+                        </td>
+                    </tr>
+
+                    <tr style="margin-top: 2%; display: block" align="center">
+                        <td>
+                            <p align="center">Join us on social media:</p>
+                            <p align="center">
+                                <a style="text-decoration: none; display: inline-block; margin-left: 10px; margin-right: 20px;" href="https://github.com/kamu-data" target="_blank">
+                                    <img src="https://docs.kamu.dev/images/email/github.png" alt="GitHub logo" title="Kamu GitHub account" height="26" />
+                                </a>
+                                <a style="text-decoration: none; display: inline-block; margin-right: 20px;" href="https://discord.gg/nU6TXRQNXC" target="_blank">
+                                    <img src="https://docs.kamu.dev/images/email/discord.png" alt="Discord logo" title="Kamu Discord server" height="26" />
+                                </a>
+                                <a style="text-decoration: none; display: inline-block; margin-right: 10px;" href="https://www.youtube.com/channel/UCWciDIWI_HsJ6Md_DdyJPIQ" target="_blank">
+                                    <img src="https://docs.kamu.dev/images/email/youtube.png" alt="YouTube logo" title="Kamu YouTube channel" height="26" />
+                                </a>
+                                <a style="text-decoration: none; display: inline-block; margin-right: 15px; margin-left: 5px;" href="https://medium.com/kamu-data" target="_blank">
+                                    <img src="https://docs.kamu.dev/images/email/medium.png" alt="Medium logo" title="Kamu Medium page" height="26" />
+                                </a>
+                                <a style="text-decoration: none; display: inline-block; margin-right: 20px;" href="https://www.linkedin.com/company/kamu-data" target="_blank">
+                                    <img src="https://docs.kamu.dev/images/email/linkedin.png" alt="LinkedIn logo" title="Kamu LinkedIn profile" height="26" />
+                                </a>
+                            </p>
+                        </td>
+                    </tr>
+
+                    <tr style="margin-top: 4%; display: block" align="center">
+                        <td>
+                            <p style="margin-top: 10px">
+                                Copyright © 2025 Kamu. All rights reserved.
+                            </p>
+                        </td>
+                    </tr>
+                </table>
+            </td>
+        </tr>
+    </table>
+</body>
+
+</html>

--- a/resources/email-templates/flow-failed.html
+++ b/resources/email-templates/flow-failed.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+
+{% block extrastyles %}
+    <style>
+        .flow-details {
+            background-color: #f9f9f9;
+            border-left: 4px solid #d32f2f;
+            padding: 18px 15px;
+            margin: 0;
+            border-radius: 4px;
+            text-align: left;
+        }
+
+        strong {
+            font-weight: 700 !important;
+        }        
+
+        .details-button {
+            display: inline-block;
+            background-color: #d32f2f;
+            color: #ffffff !important;
+            text-decoration: none;
+            padding: 8px 20px;
+            border-radius: 4px;
+            font-weight: bold;
+        }
+        
+        .details-button:hover {
+            background-color: #b71c1c;
+        }
+    </style>
+{% endblock %}
+
+{% block title %}Kamu Flow Failed: {{ flow_type }} - {{ dataset_alias }}{% endblock %}
+
+{% block header %}[<a href="{{ dataset_url }}"><span class="code">{{ dataset_alias }}</span></a>] Kamu {{ flow_type }} Flow{% endblock %}
+
+{% block content %}
+
+<table align="center" border="0" cellpadding="0" cellspacing="0" style="min-width: 510px; max-width: 700px">
+    <tr align="center">
+        <td style="border: 1px solid #e1e4e8; border-radius: 6px">
+            <img style="width: 45px; margin-top: 20px" src="https://docs.kamu.dev/images/email/tree-structure.png" alt="" />
+            <p class="header">
+                <img style="width: 22px; vertical-align: sub" src="https://docs.kamu.dev/images/email/error.png" alt="error" />
+                {{ flow_type }}: Flow has failed
+            </p>
+            <p style="margin-bottom: 25px">
+                <a href="{{ flow_details_url }}" class="details-button">View details</a>
+            </p>
+
+            <div class="flow-details" style="border-top: 1px solid #e1e4e8; margin: 0">
+                <strong>Flow Type:</strong> {{ flow_type }}<br />
+                <strong>Dataset:</strong> <span class="code">{{ dataset_alias }}</span><br />
+                <strong>Trigger:</strong> {{ trigger_type }}<br />
+                <strong>Start Time:</strong> {{ start_time }} UTC<br />
+                <strong>Failure Time:</strong> {{ failure_time }} UTC<br />
+                <strong>Reason:</strong> {{ failure_reason }}
+            </div>
+        </td>
+    </tr>
+</table>
+
+{% endblock %}

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.52.1"
+    "version": "0.53.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.52.1"
+    "version": "0.53.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/schema.gql
+++ b/resources/schema.gql
@@ -38,6 +38,10 @@ type Account {
 	"""
 	accountType: AccountType!
 	"""
+	Email address
+	"""
+	email: String!
+	"""
 	Avatar URL
 	"""
 	avatarUrl: String
@@ -115,6 +119,10 @@ type AccountFlowsMut {
 scalar AccountID
 
 type AccountMut {
+	"""
+	Update account email
+	"""
+	updateEmail(newEmail: String!): UpdateEmailResult!
 	"""
 	Access to the mutable flow configurations of this account
 	"""
@@ -2012,6 +2020,25 @@ interface TriggerFlowResult {
 
 type TriggerFlowSuccess implements TriggerFlowResult {
 	flow: Flow!
+	message: String!
+}
+
+type UpdateEmailInvalid implements UpdateEmailResult {
+	dummy: Boolean!
+	message: String!
+}
+
+type UpdateEmailNonUnique implements UpdateEmailResult {
+	dummy: Boolean!
+	message: String!
+}
+
+interface UpdateEmailResult {
+	message: String!
+}
+
+type UpdateEmailSuccess implements UpdateEmailResult {
+	newEmail: String!
 	message: String!
 }
 

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -32,6 +32,8 @@ dill = { version = "0.11", default-features = false }
 container-runtime = { workspace = true }
 database-common = { workspace = true }
 database-common-macros = { workspace = true }
+email-utils = { workspace = true }
+email-gateway = { workspace = true }
 graceful-shutdown = { workspace = true }
 http-common = { workspace = true }
 init-on-startup = { workspace = true }
@@ -101,6 +103,8 @@ prometheus = { version = "0.13", default-features = false }
 tracing = "0.1"
 
 # Utils
+async-trait = { version = "0.1", default-features = false }
+askama = { version = "0.12" }
 chrono = "0.4"
 clap = { version = "4", default-features = false, features = [
     "std",
@@ -133,6 +137,7 @@ url = "2"
 
 
 [dev-dependencies]
+email-gateway = { workspace = true, features = ["testing"] }
 kamu = { workspace = true, features = ["testing"] }
 test-utils = { workspace = true }
 

--- a/src/app/api-server/askama.toml
+++ b/src/app/api-server/askama.toml
@@ -1,0 +1,2 @@
+[general]
+dirs = ["../../../resources/email-templates"]

--- a/src/app/api-server/src/config.rs
+++ b/src/app/api-server/src/config.rs
@@ -49,6 +49,8 @@ pub struct ApiServerConfig {
     pub source: SourceConfig,
     /// Outbox configuration
     pub outbox: OutboxConfig,
+    /// Email gateway configuration
+    pub email: EmailConfig,
     /// UNSTABLE: Identity configuration
     pub identity: Option<IdentityConfig>,
 }
@@ -693,6 +695,39 @@ impl IdentityConfig {
             .clone()
             .map(|private_key| kamu_adapter_http::data::query_types::IdentityConfig { private_key })
     }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailConfig {
+    pub sender_address: String,
+    pub sender_name: Option<String>,
+    pub gateway: EmailConfigGateway,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+#[serde(tag = "kind")]
+pub enum EmailConfigGateway {
+    Dummy,
+    Postmark(EmailConfigPostmarkGateway),
+}
+
+impl Default for EmailConfigGateway {
+    fn default() -> Self {
+        Self::Dummy
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+#[serde(rename_all = "camelCase")]
+pub struct EmailConfigPostmarkGateway {
+    pub api_key: String,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/api-server/src/emails/account_lifecycle_notifier.rs
+++ b/src/app/api-server/src/emails/account_lifecycle_notifier.rs
@@ -1,0 +1,109 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use askama::Template;
+use dill::{component, interface, meta, Catalog};
+use email_gateway::EmailSender;
+use internal_error::{InternalError, ResultIntoInternal};
+use kamu_accounts::{
+    AccountLifecycleMessage,
+    AccountLifecycleMessageCreated,
+    MESSAGE_PRODUCER_KAMU_ACCOUNTS_SERVICE,
+};
+use messaging_outbox::{
+    MessageConsumer,
+    MessageConsumerMeta,
+    MessageConsumerT,
+    MessageDeliveryMechanism,
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub const ACCOUNT_REGISTERED_SUBJECT: &str = "Welcome to Kamu!";
+
+pub const MESSAGE_CONSUMER_KAMU_API_SERVER_ACCOUNT_LIFECYCLE_NOTIFIER: &str =
+    "dev.kamu.api-server.AccountLifecycleNotifier";
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct AccountLifecycleNotifier {
+    email_sender: Arc<dyn EmailSender>,
+}
+
+#[component(pub)]
+#[interface(dyn MessageConsumer)]
+#[interface(dyn MessageConsumerT<AccountLifecycleMessage>)]
+#[meta(MessageConsumerMeta {
+    consumer_name: MESSAGE_CONSUMER_KAMU_API_SERVER_ACCOUNT_LIFECYCLE_NOTIFIER,
+    feeding_producers: &[
+        MESSAGE_PRODUCER_KAMU_ACCOUNTS_SERVICE,
+    ],
+    delivery: MessageDeliveryMechanism::Transactional,
+})]
+impl AccountLifecycleNotifier {
+    pub fn new(email_sender: Arc<dyn EmailSender>) -> Self {
+        Self { email_sender }
+    }
+
+    async fn notify_account_created(
+        &self,
+        created: &AccountLifecycleMessageCreated,
+    ) -> Result<(), InternalError> {
+        let registration_email = RegistrationEmail {
+            username: &created.display_name,
+        };
+        let rendered_registration_body = registration_email.render().unwrap();
+
+        self.email_sender
+            .send_email(
+                &created.email,
+                ACCOUNT_REGISTERED_SUBJECT,
+                &rendered_registration_body,
+            )
+            .await
+            .int_err()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl MessageConsumer for AccountLifecycleNotifier {}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+impl MessageConsumerT<AccountLifecycleMessage> for AccountLifecycleNotifier {
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        name = "AccountLifecycleNotifier[AccountLifecycleMessage]"
+    )]
+    async fn consume_message(
+        &self,
+        _: &Catalog,
+        message: &AccountLifecycleMessage,
+    ) -> Result<(), InternalError> {
+        tracing::debug!(received_message = ?message, "Received account lifecycle message");
+        match message {
+            AccountLifecycleMessage::Created(created) => self.notify_account_created(created).await,
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Template)]
+#[template(path = "account-registered.html")]
+struct RegistrationEmail<'a> {
+    username: &'a str,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/api-server/src/emails/flow_progress_notifier.rs
+++ b/src/app/api-server/src/emails/flow_progress_notifier.rs
@@ -1,0 +1,342 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use askama::Template;
+use chrono::{DateTime, Utc};
+use dill::{component, interface, meta, Catalog};
+use email_gateway::EmailSender;
+use internal_error::{InternalError, ResultIntoInternal};
+use kamu_flow_system as kamu_fs;
+use messaging_outbox::{
+    MessageConsumer,
+    MessageConsumerMeta,
+    MessageConsumerT,
+    MessageDeliveryMechanism,
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub const FLOW_FAILED_SUBJECT: &str = "Kamu Flow Run Failed";
+
+pub const MESSAGE_CONSUMER_KAMU_API_SERVER_FLOW_PROGRESS_NOTIFIER: &str =
+    "dev.kamu.api-server.FlowProgressNotifier";
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct FlowProgressNotifier {
+    email_sender: Arc<dyn EmailSender>,
+    flow_query_service: Arc<dyn kamu_fs::FlowQueryService>,
+    dataset_entry_service: Arc<dyn kamu_datasets::DatasetEntryService>,
+    authentication_service: Arc<dyn kamu_accounts::AuthenticationService>,
+    server_url_config: Arc<kamu::domain::ServerUrlConfig>,
+    tenancy_config: Arc<kamu::domain::TenancyConfig>,
+}
+
+#[component(pub)]
+#[interface(dyn MessageConsumer)]
+#[interface(dyn MessageConsumerT<kamu_fs::FlowProgressMessage>)]
+#[meta(MessageConsumerMeta {
+    consumer_name: MESSAGE_CONSUMER_KAMU_API_SERVER_FLOW_PROGRESS_NOTIFIER,
+    feeding_producers: &[
+        kamu_flow_system_services::MESSAGE_PRODUCER_KAMU_FLOW_PROGRESS_SERVICE,
+    ],
+    delivery: MessageDeliveryMechanism::Transactional,
+})]
+impl FlowProgressNotifier {
+    pub fn new(
+        email_sender: Arc<dyn EmailSender>,
+        flow_query_service: Arc<dyn kamu_fs::FlowQueryService>,
+        dataset_entry_service: Arc<dyn kamu_datasets::DatasetEntryService>,
+        authentication_service: Arc<dyn kamu_accounts::AuthenticationService>,
+        server_url_config: Arc<kamu::domain::ServerUrlConfig>,
+        tenancy_config: Arc<kamu::domain::TenancyConfig>,
+    ) -> Self {
+        Self {
+            email_sender,
+            flow_query_service,
+            dataset_entry_service,
+            authentication_service,
+            server_url_config,
+            tenancy_config,
+        }
+    }
+
+    async fn notify_flow_failed(
+        &self,
+        flow_id: kamu_fs::FlowID,
+        flow_error: &kamu_fs::FlowError,
+    ) -> Result<(), InternalError> {
+        // Load flow aggregate
+        let flow_state = self.flow_query_service.get_flow(flow_id).await.int_err()?;
+        match &flow_state.flow_key {
+            // Dataset flow => notify owner or initiator
+            kamu_fs::FlowKey::Dataset(fk_dataset) => {
+                // Load related dataset entry
+                let dataset_entry = self
+                    .dataset_entry_service
+                    .get_entry(&fk_dataset.dataset_id)
+                    .await
+                    .int_err()?;
+
+                // Owner account is needed for proper links as a minimum
+                let owner_account = self
+                    .authentication_service
+                    .account_by_id(&dataset_entry.owner_id)
+                    .await
+                    .int_err()?
+                    .unwrap();
+
+                // Select recipient: manual different launched person or owner
+                let recipient_account = self
+                    .select_dataset_flow_recipient(&owner_account, &flow_state)
+                    .await?;
+
+                // Render email
+                let rendered_email = self
+                    .render_dataset_flow_failure_email(
+                        &owner_account,
+                        &dataset_entry,
+                        fk_dataset,
+                        FlowFailureData {
+                            id: flow_id,
+                            error: flow_error,
+                            started_at: flow_state
+                                .timing
+                                .running_since
+                                .expect("Start time should be defined"),
+                            occurred_at: flow_state
+                                .timing
+                                .finished_at
+                                .expect("Finish time should be defined"),
+                            primary_trigger_type: flow_state.primary_trigger(),
+                        },
+                    )
+                    .await?;
+
+                // Format subject
+                let email_subject = format!(
+                    "{}: {}",
+                    FLOW_FAILED_SUBJECT,
+                    self.format_dataset_alias(&owner_account, &dataset_entry)
+                );
+
+                // Deliver email to selected recipient
+                self.email_sender
+                    .send_email(&recipient_account.email, &email_subject, &rendered_email)
+                    .await
+                    .int_err()?;
+            }
+
+            // TODO: notify admin(s) about system flow failure?
+            kamu_fs::FlowKey::System(_) => {}
+        }
+
+        Ok(())
+    }
+
+    async fn select_dataset_flow_recipient<'a>(
+        &self,
+        owner_account: &'a kamu_accounts::Account,
+        flow_state: &'a kamu_fs::FlowState,
+    ) -> Result<Cow<'a, kamu_accounts::Account>, InternalError> {
+        if let kamu_fs::FlowTriggerType::Manual(m) = flow_state.primary_trigger()
+            && m.initiator_account_id != owner_account.id
+        {
+            let initiator_account = self
+                .authentication_service
+                .account_by_id(&m.initiator_account_id)
+                .await?
+                .expect("Account must be resolved");
+            return Ok(Cow::Owned(initiator_account));
+        }
+
+        Ok(Cow::Borrowed(owner_account))
+    }
+
+    async fn render_dataset_flow_failure_email(
+        &self,
+        owner_account: &kamu_accounts::Account,
+        dataset_entry: &kamu_datasets::DatasetEntry,
+        flow_key_dataset: &kamu_fs::FlowKeyDataset,
+        flow_failure_data: FlowFailureData<'_>,
+    ) -> Result<String, InternalError> {
+        let dataset_alias = self.format_dataset_alias(owner_account, dataset_entry);
+        let dataset_url = self.format_dataset_url(owner_account, dataset_entry);
+        let flow_details_url =
+            self.format_flow_details_url(owner_account, dataset_entry, flow_failure_data.id);
+
+        let failure_time = flow_failure_data
+            .occurred_at
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        let start_time = flow_failure_data
+            .started_at
+            .format("%Y-%m-%d %H:%M:%S")
+            .to_string();
+
+        let failure_reason = self
+            .format_flow_failure_reason(flow_failure_data.error)
+            .await?;
+
+        let email = FlowFailedEmail {
+            flow_type: self.format_dataset_flow_type(flow_key_dataset),
+            dataset_alias: &dataset_alias,
+            dataset_url: dataset_url.as_str(),
+            trigger_type: self.format_flow_trigger_type(flow_failure_data.primary_trigger_type),
+            failure_reason: &failure_reason,
+            start_time: start_time.as_str(),
+            failure_time: failure_time.as_str(),
+            flow_details_url: &flow_details_url,
+        };
+
+        email.render().int_err()
+    }
+
+    fn format_dataset_flow_type(&self, fk_dataset: &kamu_fs::FlowKeyDataset) -> &str {
+        match fk_dataset.flow_type {
+            kamu_fs::DatasetFlowType::Ingest | kamu_fs::DatasetFlowType::ExecuteTransform => {
+                "Update"
+            }
+            kamu_fs::DatasetFlowType::HardCompaction => "Compact",
+            kamu_fs::DatasetFlowType::Reset => "Reset",
+        }
+    }
+
+    fn format_flow_trigger_type(&self, flow_trigger_type: &kamu_fs::FlowTriggerType) -> &str {
+        match flow_trigger_type {
+            kamu_fs::FlowTriggerType::AutoPolling(_) => "Automatic",
+            kamu_fs::FlowTriggerType::Manual(_) => "Manual",
+            kamu_fs::FlowTriggerType::Push(_) => "Data Push",
+            kamu_fs::FlowTriggerType::InputDatasetFlow(_) => "Input Dataset Flow",
+        }
+    }
+
+    async fn format_flow_failure_reason(
+        &self,
+        flow_error: &kamu_fs::FlowError,
+    ) -> Result<String, InternalError> {
+        match flow_error {
+            kamu_fs::FlowError::Failed => Ok("Unknown".to_string()),
+            kamu_fs::FlowError::InputDatasetCompacted(c) => {
+                let input_dataset_entry = self
+                    .dataset_entry_service
+                    .get_entry(&c.dataset_id)
+                    .await
+                    .int_err()?;
+                Ok(format!(
+                    "Input dataset '{}' compacted",
+                    input_dataset_entry.name
+                ))
+            }
+            kamu_fs::FlowError::ResetHeadNotFound => Ok("Reset head not found".to_string()),
+        }
+    }
+
+    fn format_dataset_alias(
+        &self,
+        owner_account: &kamu_accounts::Account,
+        dataset_entry: &kamu_datasets::DatasetEntry,
+    ) -> String {
+        match self.tenancy_config.as_ref() {
+            kamu::domain::TenancyConfig::SingleTenant => format!("{}", dataset_entry.name),
+            kamu::domain::TenancyConfig::MultiTenant => {
+                format!("{}/{}", owner_account.account_name, dataset_entry.name)
+            }
+        }
+    }
+
+    fn format_dataset_url(
+        &self,
+        owner_account: &kamu_accounts::Account,
+        dataset_entry: &kamu_datasets::DatasetEntry,
+    ) -> String {
+        format!(
+            "{}{}",
+            self.server_url_config.protocols.base_url_platform,
+            self.format_dataset_alias(owner_account, dataset_entry)
+        )
+    }
+
+    fn format_flow_details_url(
+        &self,
+        owner_account: &kamu_accounts::Account,
+        dataset_entry: &kamu_datasets::DatasetEntry,
+        flow_id: kamu_fs::FlowID,
+    ) -> String {
+        format!(
+            "{}/flow-details/{}/history",
+            self.format_dataset_url(owner_account, dataset_entry),
+            flow_id,
+        )
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+impl MessageConsumer for FlowProgressNotifier {}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+impl MessageConsumerT<kamu_fs::FlowProgressMessage> for FlowProgressNotifier {
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        name = "FlowProgressNotifier[FlowProgressMessage]"
+    )]
+    async fn consume_message(
+        &self,
+        _: &Catalog,
+        message: &kamu_fs::FlowProgressMessage,
+    ) -> Result<(), InternalError> {
+        tracing::debug!(received_message = ?message, "Received flow progress message");
+        match message {
+            kamu_fs::FlowProgressMessage::Finished(finished) => match &finished.outcome {
+                kamu_fs::FlowOutcome::Failed(flow_error) => {
+                    self.notify_flow_failed(finished.flow_id, flow_error).await
+                }
+                kamu_fs::FlowOutcome::Aborted | kamu_fs::FlowOutcome::Success(_) => Ok(()),
+            },
+            kamu_fs::FlowProgressMessage::Cancelled(_)
+            | kamu_fs::FlowProgressMessage::Running(_)
+            | kamu_fs::FlowProgressMessage::Scheduled(_) => Ok(()),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct FlowFailureData<'a> {
+    id: kamu_fs::FlowID,
+    primary_trigger_type: &'a kamu_fs::FlowTriggerType,
+    started_at: DateTime<Utc>,
+    occurred_at: DateTime<Utc>,
+    error: &'a kamu_fs::FlowError,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Template)]
+#[template(path = "flow-failed.html")]
+struct FlowFailedEmail<'a> {
+    flow_type: &'a str,
+    dataset_alias: &'a str,
+    dataset_url: &'a str,
+    trigger_type: &'a str,
+    start_time: &'a str,
+    failure_time: &'a str,
+    failure_reason: &'a str,
+    flow_details_url: &'a str,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/api-server/src/emails/mod.rs
+++ b/src/app/api-server/src/emails/mod.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod account_lifecycle_notifier;
+mod flow_progress_notifier;
+
+pub use account_lifecycle_notifier::*;
+pub use flow_progress_notifier::*;

--- a/src/app/api-server/src/lib.rs
+++ b/src/app/api-server/src/lib.rs
@@ -21,3 +21,6 @@ pub mod ui_configuration;
 
 pub use app::*;
 pub(crate) use database::*;
+
+mod emails;
+pub use emails::*;

--- a/src/app/api-server/tests/tests/notifiers/mod.rs
+++ b/src/app/api-server/tests/tests/notifiers/mod.rs
@@ -7,6 +7,5 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod test_account_lifecycle_notifier;
+mod test_flow_progress_notifier;

--- a/src/app/api-server/tests/tests/notifiers/test_account_lifecycle_notifier.rs
+++ b/src/app/api-server/tests/tests/notifiers/test_account_lifecycle_notifier.rs
@@ -1,0 +1,101 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use dill::*;
+use email_gateway::FakeEmailSender;
+use email_utils::Email;
+use kamu_accounts::{
+    AccountDisplayName,
+    AccountLifecycleMessage,
+    MESSAGE_PRODUCER_KAMU_ACCOUNTS_SERVICE,
+};
+use kamu_api_server::{AccountLifecycleNotifier, ACCOUNT_REGISTERED_SUBJECT};
+use messaging_outbox::{register_message_dispatcher, Outbox, OutboxExt, OutboxImmediateImpl};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_account_created_sends_registration_email() {
+    let harness = AccountLifecycleNotifierHarness::new();
+    harness
+        .send_account_created(
+            odf::AccountName::new_unchecked("wasya"),
+            AccountDisplayName::from("Wasya Pupkin"),
+            Email::parse("wasya@example.com").unwrap(),
+        )
+        .await;
+
+    let emails = harness.fake_email_sender.get_recorded_emails();
+    assert_eq!(emails.len(), 1);
+
+    let registration_email = emails.first().unwrap();
+    assert_eq!(registration_email.recipient.as_ref(), "wasya@example.com");
+    assert_eq!(registration_email.subject, ACCOUNT_REGISTERED_SUBJECT);
+    assert!(registration_email.body.contains("Wasya Pupkin"));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct AccountLifecycleNotifierHarness {
+    _catalog: Catalog,
+    outbox: Arc<dyn Outbox>,
+    fake_email_sender: Arc<FakeEmailSender>,
+}
+
+impl AccountLifecycleNotifierHarness {
+    fn new() -> Self {
+        let mut b = dill::CatalogBuilder::new();
+
+        b.add::<AccountLifecycleNotifier>()
+            .add_builder(
+                messaging_outbox::OutboxImmediateImpl::builder()
+                    .with_consumer_filter(messaging_outbox::ConsumerFilter::AllConsumers),
+            )
+            .bind::<dyn Outbox, OutboxImmediateImpl>()
+            .add::<FakeEmailSender>();
+
+        register_message_dispatcher::<AccountLifecycleMessage>(
+            &mut b,
+            MESSAGE_PRODUCER_KAMU_ACCOUNTS_SERVICE,
+        );
+
+        let catalog = b.build();
+        let outbox = catalog.get_one().unwrap();
+        let fake_email_sender = catalog.get_one().unwrap();
+
+        Self {
+            _catalog: catalog,
+            outbox,
+            fake_email_sender,
+        }
+    }
+
+    async fn send_account_created(
+        &self,
+        account_name: odf::AccountName,
+        display_name: AccountDisplayName,
+        email: Email,
+    ) {
+        self.outbox
+            .post_message(
+                MESSAGE_PRODUCER_KAMU_ACCOUNTS_SERVICE,
+                AccountLifecycleMessage::created(
+                    odf::AccountID::new_seeded_ed25519(account_name.as_bytes()),
+                    email,
+                    display_name,
+                ),
+            )
+            .await
+            .unwrap();
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/api-server/tests/tests/notifiers/test_flow_progress_notifier.rs
+++ b/src/app/api-server/tests/tests/notifiers/test_flow_progress_notifier.rs
@@ -1,0 +1,272 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use chrono::{TimeDelta, Utc};
+use database_common::NoOpDatabasePlugin;
+use dill::*;
+use email_gateway::FakeEmailSender;
+use kamu::domain::{DidGeneratorDefault, ServerUrlConfig, TenancyConfig};
+use kamu::DatasetStorageUnitLocalFs;
+use kamu_accounts::{
+    CurrentAccountSubject,
+    JwtAuthenticationConfig,
+    PredefinedAccountsConfig,
+    DEFAULT_ACCOUNT_NAME_STR,
+    DUMMY_EMAIL_ADDRESS,
+};
+use kamu_accounts_inmem::{InMemoryAccessTokenRepository, InMemoryAccountRepository};
+use kamu_accounts_services::{
+    AccessTokenServiceImpl,
+    AuthenticationServiceImpl,
+    LoginPasswordAuthProvider,
+    PredefinedAccountsRegistrator,
+};
+use kamu_api_server::{FlowProgressNotifier, FLOW_FAILED_SUBJECT};
+use kamu_datasets::{DatasetEntry, DatasetEntryRepository};
+use kamu_datasets_inmem::InMemoryDatasetEntryRepository;
+use kamu_datasets_services::DatasetEntryServiceImpl;
+use kamu_flow_system::{
+    Flow,
+    FlowAgentConfig,
+    FlowError,
+    FlowEventStore,
+    FlowID,
+    FlowKey,
+    FlowOutcome,
+    FlowProgressMessage,
+    FlowResult,
+    FlowStartConditionExecutor,
+    FlowTriggerAutoPolling,
+};
+use kamu_flow_system_inmem::InMemoryFlowEventStore;
+use kamu_flow_system_services::{
+    FlowQueryServiceImpl,
+    MESSAGE_PRODUCER_KAMU_FLOW_PROGRESS_SERVICE,
+};
+use kamu_task_system::{TaskError, TaskID, TaskOutcome, TaskResult};
+use messaging_outbox::{register_message_dispatcher, Outbox, OutboxExt, OutboxImmediateImpl};
+use odf::DatasetID;
+use tempfile::TempDir;
+use time_source::SystemTimeSourceDefault;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_failed_flow_sends_email() {
+    let harness = FlowProgressNotifierHarness::new().await;
+
+    let dataset_id = odf::DatasetID::new_seeded_ed25519(b"test-dataset");
+    let dataset_name = odf::DatasetName::new_unchecked("test-dataset");
+
+    harness.make_dataset(&dataset_id, &dataset_name).await;
+    harness.send_flow_failed(&dataset_id).await;
+
+    let emails = harness.fake_email_sender.get_recorded_emails();
+    assert_eq!(emails.len(), 1);
+
+    let flow_failed_email = emails.first().unwrap();
+    assert_eq!(
+        flow_failed_email.recipient.as_ref(),
+        DUMMY_EMAIL_ADDRESS.as_ref()
+    );
+    assert_eq!(
+        flow_failed_email.subject,
+        format!("{FLOW_FAILED_SUBJECT}: test-dataset")
+    );
+    assert!(flow_failed_email
+        .body
+        .contains("href=\"http://platform.example.com/test-dataset/flow-details/0/history\""));
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[test_log::test(tokio::test)]
+async fn test_success_flow_gives_no_emails() {
+    let harness = FlowProgressNotifierHarness::new().await;
+
+    let dataset_id = odf::DatasetID::new_seeded_ed25519(b"test-dataset");
+    let dataset_name = odf::DatasetName::new_unchecked("test-dataset");
+
+    harness.make_dataset(&dataset_id, &dataset_name).await;
+    harness.send_flow_success(&dataset_id).await;
+
+    let emails = harness.fake_email_sender.get_recorded_emails();
+    assert_eq!(emails.len(), 0);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+struct FlowProgressNotifierHarness {
+    _tempdir: TempDir,
+    catalog: Catalog,
+    outbox: Arc<dyn Outbox>,
+    fake_email_sender: Arc<FakeEmailSender>,
+}
+
+impl FlowProgressNotifierHarness {
+    async fn new() -> Self {
+        let mut b = dill::CatalogBuilder::new();
+
+        let tempdir = tempfile::tempdir().unwrap();
+        let datasets_dir = tempdir.path().join("datasets");
+        std::fs::create_dir(&datasets_dir).unwrap();
+
+        b.add::<FlowProgressNotifier>()
+            .add_value(TenancyConfig::SingleTenant)
+            .add_builder(
+                messaging_outbox::OutboxImmediateImpl::builder()
+                    .with_consumer_filter(messaging_outbox::ConsumerFilter::AllConsumers),
+            )
+            .bind::<dyn Outbox, OutboxImmediateImpl>()
+            .add::<FakeEmailSender>()
+            // TODO: use mocks to avoid this boilerplate, but it's waiting for kamu-cli#1010
+            .add::<FlowQueryServiceImpl>()
+            .add::<InMemoryFlowEventStore>()
+            .add::<DatasetEntryServiceImpl>()
+            .add::<InMemoryDatasetEntryRepository>()
+            .add::<DidGeneratorDefault>()
+            .add::<SystemTimeSourceDefault>()
+            .add_builder(DatasetStorageUnitLocalFs::builder().with_root(datasets_dir))
+            .bind::<dyn odf::DatasetStorageUnit, DatasetStorageUnitLocalFs>()
+            .add_value(CurrentAccountSubject::new_test())
+            .add_value(FlowAgentConfig::new(
+                TimeDelta::seconds(1),
+                TimeDelta::minutes(1),
+            ))
+            .add::<InMemoryAccountRepository>()
+            .add::<AuthenticationServiceImpl>()
+            .add::<AccessTokenServiceImpl>()
+            .add::<InMemoryAccessTokenRepository>()
+            .add::<PredefinedAccountsRegistrator>()
+            .add::<LoginPasswordAuthProvider>()
+            .add_value(PredefinedAccountsConfig::single_tenant())
+            .add_value(JwtAuthenticationConfig::default())
+            .add_value(ServerUrlConfig::new_test(None));
+
+        NoOpDatabasePlugin::init_database_components(&mut b);
+
+        register_message_dispatcher::<FlowProgressMessage>(
+            &mut b,
+            MESSAGE_PRODUCER_KAMU_FLOW_PROGRESS_SERVICE,
+        );
+
+        let catalog = b.build();
+
+        init_on_startup::run_startup_jobs(&catalog).await.unwrap();
+
+        let outbox = catalog.get_one().unwrap();
+        let fake_email_sender = catalog.get_one().unwrap();
+
+        Self {
+            _tempdir: tempdir,
+            catalog,
+            outbox,
+            fake_email_sender,
+        }
+    }
+
+    async fn make_dataset(&self, dataset_id: &DatasetID, dataset_name: &odf::DatasetName) {
+        let dataset_entry_repo = self
+            .catalog
+            .get_one::<dyn DatasetEntryRepository>()
+            .unwrap();
+
+        dataset_entry_repo
+            .save_dataset_entry(&DatasetEntry {
+                id: dataset_id.clone(),
+                owner_id: odf::AccountID::new_seeded_ed25519(DEFAULT_ACCOUNT_NAME_STR.as_bytes()),
+                name: dataset_name.clone(),
+                created_at: Utc::now(),
+            })
+            .await
+            .unwrap();
+    }
+
+    async fn send_flow_success(&self, dataset_id: &DatasetID) {
+        let flow_event_store = self.catalog.get_one::<dyn FlowEventStore>().unwrap();
+        let flow_id = flow_event_store.new_flow_id().await.unwrap();
+
+        let (mut flow, task_id) = self.create_and_prepare_flow(dataset_id, flow_id);
+
+        flow.on_task_finished(Utc::now(), task_id, TaskOutcome::Success(TaskResult::Empty))
+            .unwrap();
+
+        flow.save(flow_event_store.as_ref()).await.unwrap();
+
+        self.outbox
+            .post_message(
+                MESSAGE_PRODUCER_KAMU_FLOW_PROGRESS_SERVICE,
+                FlowProgressMessage::finished(
+                    Utc::now(),
+                    flow.flow_id,
+                    FlowOutcome::Success(FlowResult::Empty),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+
+    async fn send_flow_failed(&self, dataset_id: &DatasetID) {
+        let flow_event_store = self.catalog.get_one::<dyn FlowEventStore>().unwrap();
+        let flow_id = flow_event_store.new_flow_id().await.unwrap();
+
+        let (mut flow, task_id) = self.create_and_prepare_flow(dataset_id, flow_id);
+
+        flow.on_task_finished(Utc::now(), task_id, TaskOutcome::Failed(TaskError::Empty))
+            .unwrap();
+
+        flow.save(flow_event_store.as_ref()).await.unwrap();
+
+        self.outbox
+            .post_message(
+                MESSAGE_PRODUCER_KAMU_FLOW_PROGRESS_SERVICE,
+                FlowProgressMessage::finished(
+                    Utc::now(),
+                    flow.flow_id,
+                    FlowOutcome::Failed(FlowError::Failed),
+                ),
+            )
+            .await
+            .unwrap();
+    }
+
+    fn create_and_prepare_flow(&self, dataset_id: &DatasetID, flow_id: FlowID) -> (Flow, TaskID) {
+        let mut flow = Flow::new(
+            Utc::now(),
+            flow_id,
+            FlowKey::dataset(
+                dataset_id.clone(),
+                kamu_flow_system::DatasetFlowType::Ingest,
+            ),
+            kamu_flow_system::FlowTriggerType::AutoPolling(FlowTriggerAutoPolling {
+                trigger_time: Utc::now(),
+            }),
+            None,
+        );
+
+        flow.schedule_for_activation(Utc::now(), Utc::now())
+            .unwrap();
+
+        let task_id = TaskID::new(1);
+        flow.set_relevant_start_condition(
+            Utc::now(),
+            kamu_flow_system::FlowStartCondition::Executor(FlowStartConditionExecutor { task_id }),
+        )
+        .unwrap();
+
+        flow.on_task_scheduled(Utc::now(), task_id).unwrap();
+        flow.on_task_running(Utc::now(), task_id).unwrap();
+
+        (flow, task_id)
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/app/api-server/tests/tests/test_di_graph.rs
+++ b/src/app/api-server/tests/tests/test_di_graph.rs
@@ -21,7 +21,9 @@ async fn test_di_graph_validates_local() {
     let repo_url = url::Url::from_directory_path(tempdir.path()).unwrap();
 
     let mut catalog_builder =
-        kamu_api_server::init_dependencies(config, &repo_url, tenancy_config, tempdir.path()).await;
+        kamu_api_server::init_dependencies(config, &repo_url, tenancy_config, tempdir.path())
+            .await
+            .unwrap();
 
     // CurrentAccountSubject is inserted by middlewares, but won't be present in
     // the default dependency graph, so we have to add it manually
@@ -74,7 +76,8 @@ async fn test_di_graph_validates_remote() {
 
     let mut catalog_builder =
         kamu_api_server::init_dependencies(config, &repo_url, tenancy_config, tmp_repo_dir.path())
-            .await;
+            .await
+            .unwrap();
 
     // CurrentAccountSubject is inserted by middlewares, but won't be present in
     // the default dependency graph, so we have to add it manually

--- a/src/utils/email-gateway/Cargo.toml
+++ b/src/utils/email-gateway/Cargo.toml
@@ -1,0 +1,43 @@
+[package]
+name = "email-gateway"
+description = "General purpose email gateway"
+version = { workspace = true }
+homepage = { workspace = true }
+repository = { workspace = true }
+authors = { workspace = true }
+readme = { workspace = true }
+license-file = { workspace = true }
+keywords = { workspace = true }
+include = { workspace = true }
+edition = { workspace = true }
+publish = { workspace = true }
+
+
+[lints]
+workspace = true
+
+
+[lib]
+doctest = false
+
+[features]
+default = []
+postmark = []
+testing = []
+
+
+[dependencies]
+email-utils = { workspace = true }
+internal-error = { workspace = true }
+
+async-trait = "0.1"
+dill = "0.11"
+reqwest = { version = "0.12", default-features = false, features = ["json"] }
+secrecy = "0.10"
+serde = { version = "1", default-features = false }
+serde_json = "1"
+thiserror = { version = "2", default-features = false, features = ["std"] }
+tracing = "0.1"
+
+
+[dev-dependencies]

--- a/src/utils/email-gateway/src/dependencies.rs
+++ b/src/utils/email-gateway/src/dependencies.rs
@@ -1,0 +1,45 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use dill::CatalogBuilder;
+
+use crate::*;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug)]
+pub enum EmailConfig {
+    Dummy,
+    #[cfg(feature = "postmark")]
+    Postmark(PostmarkGatewaySettings),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub fn register_dependencies(catalog_builder: &mut CatalogBuilder, email_config: EmailConfig) {
+    match email_config {
+        EmailConfig::Dummy => {
+            catalog_builder.add::<DummyEmailSender>();
+        }
+        #[cfg(feature = "postmark")]
+        EmailConfig::Postmark(postmark_settings) => {
+            catalog_builder.add_value(postmark_settings);
+            catalog_builder.add::<PostmarkEmailSender>();
+        }
+        #[allow(unreachable_patterns)]
+        _ => {
+            panic!(
+                "Email gateway '{email_config:?}' is unavailable, compile with the corresponding \
+                 feature enabled",
+            );
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/lib.rs
+++ b/src/utils/email-gateway/src/lib.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod dependencies;
+mod services;
+
+pub use dependencies::*;
+pub use services::*;

--- a/src/utils/email-gateway/src/services/dummy/dummy_email_sender.rs
+++ b/src/utils/email-gateway/src/services/dummy/dummy_email_sender.rs
@@ -1,0 +1,40 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use dill::{component, interface};
+use email_utils::Email;
+
+use crate::{EmailSender, SendEmailError};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[component(pub)]
+#[interface[dyn EmailSender]]
+pub struct DummyEmailSender {}
+
+#[async_trait::async_trait]
+impl EmailSender for DummyEmailSender {
+    #[tracing::instrument(level = "info", skip_all, fields(recipient = recipient.as_ref(), subject))]
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        body: &str,
+    ) -> Result<(), SendEmailError> {
+        println!(
+            "Dummmy Email Sender: recipient = '{}', subject = '{subject}'",
+            recipient.as_ref()
+        );
+        println!("{body}");
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/services/dummy/mod.rs
+++ b/src/utils/email-gateway/src/services/dummy/mod.rs
@@ -7,6 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod dummy_email_sender;
+
+pub use dummy_email_sender::*;

--- a/src/utils/email-gateway/src/services/email_sender.rs
+++ b/src/utils/email-gateway/src/services/email_sender.rs
@@ -1,0 +1,34 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use email_utils::Email;
+use internal_error::InternalError;
+use thiserror::Error;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+pub trait EmailSender: Send + Sync {
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        body: &str,
+    ) -> Result<(), SendEmailError>;
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Error)]
+pub enum SendEmailError {
+    #[error(transparent)]
+    Internal(#[from] InternalError),
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/services/mod.rs
+++ b/src/utils/email-gateway/src/services/mod.rs
@@ -7,6 +7,24 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod dummy;
+mod email_sender;
+
+pub use dummy::*;
+pub use email_sender::*;
+
+// ----
+
+#[cfg(feature = "postmark")]
+mod postmark;
+
+#[cfg(feature = "postmark")]
+pub use postmark::*;
+
+// ----
+
+#[cfg(feature = "testing")]
+mod testing;
+
+#[cfg(feature = "testing")]
+pub use testing::*;

--- a/src/utils/email-gateway/src/services/postmark/mod.rs
+++ b/src/utils/email-gateway/src/services/postmark/mod.rs
@@ -7,6 +7,8 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod postmark_email_sender;
+mod postmark_gateway_settings;
+
+pub use postmark_email_sender::*;
+pub use postmark_gateway_settings::*;

--- a/src/utils/email-gateway/src/services/postmark/postmark_email_sender.rs
+++ b/src/utils/email-gateway/src/services/postmark/postmark_email_sender.rs
@@ -1,0 +1,92 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::Arc;
+
+use dill::{component, interface, scope, Singleton};
+use email_utils::Email;
+use internal_error::ResultIntoInternal;
+use secrecy::ExposeSecret;
+
+use crate::{EmailSender, PostmarkGatewaySettings, SendEmailError};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+const POSTMARK_EMAIL_API_URL: &str = "https://api.postmarkapp.com/email";
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct PostmarkEmailSender {
+    postmark_settings: Arc<PostmarkGatewaySettings>,
+    rest_client: reqwest::Client,
+    from_field: String,
+}
+
+#[component(pub)]
+#[scope(Singleton)] // To reuse `reqwest::Client`
+#[interface[dyn EmailSender]]
+impl PostmarkEmailSender {
+    pub fn new(postmark_settings: Arc<PostmarkGatewaySettings>) -> Self {
+        // Cache the "From" field once - it won't change dynamcially
+        let from_field = postmark_settings.compose_from_field();
+
+        Self {
+            postmark_settings,
+            rest_client: reqwest::Client::new(),
+            from_field,
+        }
+    }
+
+    fn should_ignore_recipient(&self, recipient: &Email) -> bool {
+        recipient.host() == "example.com"
+    }
+}
+
+#[async_trait::async_trait]
+impl EmailSender for PostmarkEmailSender {
+    #[tracing::instrument(level = "info", skip_all, fields(recipient = recipient.as_ref(), subject))]
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        body: &str,
+    ) -> Result<(), SendEmailError> {
+        if self.should_ignore_recipient(recipient) {
+            tracing::debug!(
+                recipient = recipient.as_ref(),
+                "Sending email to recipient ignored"
+            );
+            return Ok(());
+        }
+
+        let payload = serde_json::json!({
+            "From": self.from_field,
+            "To": recipient.as_ref(),
+            "Subject": subject,
+            "HtmlBody": body,
+        });
+        let response = self
+            .rest_client
+            .post(POSTMARK_EMAIL_API_URL)
+            .header(
+                "X-Postmark-Server-Token",
+                self.postmark_settings.api_key.expose_secret(),
+            )
+            .json(&payload)
+            .send()
+            .await
+            .int_err()?;
+
+        tracing::debug!(response = ?response, "Postmark response");
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/services/postmark/postmark_gateway_settings.rs
+++ b/src/utils/email-gateway/src/services/postmark/postmark_gateway_settings.rs
@@ -1,0 +1,32 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use email_utils::Email;
+use secrecy::SecretString;
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone)]
+pub struct PostmarkGatewaySettings {
+    pub sender_address: Email,
+    pub sender_name: Option<String>,
+    pub api_key: SecretString,
+}
+
+impl PostmarkGatewaySettings {
+    pub fn compose_from_field(&self) -> String {
+        match &self.sender_name {
+            // "Display Name" <email@example.com>
+            Some(sender_name) => format!("\"{}\" {}", sender_name, self.sender_address.as_ref()),
+            None => self.sender_address.as_ref().to_string(),
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/services/testing/fake_email_sender.rs
+++ b/src/utils/email-gateway/src/services/testing/fake_email_sender.rs
@@ -1,0 +1,74 @@
+// Copyright Kamu Data, Inc. and contributors. All rights reserved.
+//
+// Use of this software is governed by the Business Source License
+// included in the LICENSE file.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0.
+
+use std::sync::{Arc, Mutex};
+
+use dill::*;
+use email_utils::Email;
+
+use crate::{EmailSender, SendEmailError};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+pub struct FakeEmailSender {
+    state: Arc<Mutex<State>>,
+}
+
+#[component(pub)]
+#[interface(dyn EmailSender)]
+#[scope(Singleton)]
+impl FakeEmailSender {
+    pub fn new() -> Self {
+        Self {
+            state: Default::default(),
+        }
+    }
+
+    pub fn get_recorded_emails(&self) -> Vec<FakeEmailMessage> {
+        self.state.lock().unwrap().emails.clone()
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Default)]
+struct State {
+    emails: Vec<FakeEmailMessage>,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FakeEmailMessage {
+    pub recipient: Email,
+    pub subject: String,
+    pub body: String,
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#[async_trait::async_trait]
+impl EmailSender for FakeEmailSender {
+    async fn send_email(
+        &self,
+        recipient: &Email,
+        subject: &str,
+        body: &str,
+    ) -> Result<(), SendEmailError> {
+        self.state.lock().unwrap().emails.push(FakeEmailMessage {
+            recipient: recipient.clone(),
+            subject: subject.to_string(),
+            body: body.to_string(),
+        });
+
+        Ok(())
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/utils/email-gateway/src/services/testing/mod.rs
+++ b/src/utils/email-gateway/src/services/testing/mod.rs
@@ -7,6 +7,6 @@
 // the Business Source License, use of this software will be governed
 // by the Apache License, Version 2.0.
 
-mod api_schemas;
-mod notifiers;
-mod test_di_graph;
+mod fake_email_sender;
+
+pub use fake_email_sender::*;


### PR DESCRIPTION
## [0.53.0] - 2025-01-30
### Added
- Integration of email gateway (Postmark):
   - Defined `EmailSender` crate and prototyped `Postmark`-based implementation
   - Config support for gateway settings (API key, sender address & name)
   - Applied `askoma` templating engine and defined base HTML-rich template for all emails
   - Emails are fire-and-forget / best effort
   - First emails implemented: account registration, flow failed
- GQL suport to query and update email on the currently logged account
### Changed
- Emails are mandatory for Kamu accounts now:
   - predefined users need to specify an email in config
   - predefined users are auto-synced at startup in case they existed before
   - GitHub users are queried for primary verified email, even if it is not public
   - migration code for the database existing users