### PR TITLE
Query performance pt2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,4 @@
 target/
-/web-prototype/node_modules/
-/web-prototype/dist/
 
 .env
 /kamu.sqlite.db*

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "async-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "common-macros"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2686,7 +2686,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "container-runtime"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3000,7 +3000,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "database-common"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3026,7 +3026,7 @@ dependencies = [
 [[package]]
 name = "database-common-macros"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3911,7 +3911,7 @@ dependencies = [
 [[package]]
 name = "email-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -3960,7 +3960,7 @@ dependencies = [
 [[package]]
 name = "enum-variants"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 
 [[package]]
 name = "env_filter"
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "event-sourcing"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4038,7 +4038,7 @@ dependencies = [
 [[package]]
 name = "event-sourcing-macros"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4127,7 +4127,7 @@ dependencies = [
 [[package]]
 name = "file-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 
 [[package]]
 name = "filetime"
@@ -4797,7 +4797,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "axum 0.8.1",
  "http 1.3.1",
@@ -5180,7 +5180,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 [[package]]
 name = "init-on-startup"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5224,7 +5224,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "internal-error"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -5362,7 +5362,7 @@ dependencies = [
 [[package]]
 name = "kamu"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5431,7 +5431,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "base32",
@@ -5460,7 +5460,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5477,7 +5477,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5497,7 +5497,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5523,7 +5523,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5543,7 +5543,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5567,7 +5567,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-flight-sql"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5596,7 +5596,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-graphql"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5631,7 +5631,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-http"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5686,7 +5686,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-oauth"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "dill",
@@ -5704,7 +5704,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-odata"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -5820,7 +5820,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5835,7 +5835,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "dill",
@@ -5846,7 +5846,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5859,7 +5859,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "dill",
@@ -5879,7 +5879,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5892,7 +5892,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-common"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5924,7 +5924,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-common-macros"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -5933,7 +5933,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "chrono",
  "database-common",
@@ -5961,7 +5961,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-puppet"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5982,7 +5982,7 @@ dependencies = [
 [[package]]
 name = "kamu-core"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6015,7 +6015,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6040,7 +6040,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6057,7 +6057,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6075,7 +6075,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6106,7 +6106,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6125,7 +6125,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6151,7 +6151,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6169,7 +6169,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6187,7 +6187,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6214,7 +6214,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6232,7 +6232,7 @@ dependencies = [
 [[package]]
 name = "kamu-ingest-datafusion"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6258,7 +6258,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "dill",
@@ -6271,7 +6271,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6286,7 +6286,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6455,7 +6455,7 @@ dependencies = [
 [[package]]
 name = "kamu-search"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "futures",
@@ -6468,7 +6468,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-openai"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -6485,7 +6485,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-qdrant"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "container-runtime",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "dill",
@@ -6526,7 +6526,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6546,7 +6546,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6559,7 +6559,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-postgres"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6575,7 +6575,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-services"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6599,7 +6599,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-sqlite"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "messaging-outbox"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7103,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "multiformats"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7336,7 +7336,7 @@ dependencies = [
 [[package]]
 name = "observability"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -7406,7 +7406,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "opendatafabric"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -7422,7 +7422,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-data-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -7445,7 +7445,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-dataset"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7471,7 +7471,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-dataset-impl"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7506,7 +7506,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-metadata"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7537,7 +7537,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7556,7 +7556,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-http"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7576,7 +7576,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-inmem"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7592,7 +7592,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-lfs"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7612,7 +7612,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-s3"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8691,7 +8691,7 @@ dependencies = [
 [[package]]
 name = "random-names"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9208,7 +9208,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "s3-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -9490,7 +9490,7 @@ dependencies = [
 [[package]]
 name = "server-console"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-graphql",
  "axum 0.8.1",
@@ -10211,7 +10211,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "axum 0.8.1",
  "container-runtime",
@@ -10327,7 +10327,7 @@ dependencies = [
 [[package]]
 name = "time-source"
 version = "0.231.0"
-source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.231.0#ccbc6aad3e8f0bee8e03c6fcce3e04e71c8a6b5e"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#cf41941799c6178be8f7477aaf3fefcc80fec08f"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,68 +30,68 @@ email-gateway = { path = "src/utils/email-gateway", version = "0.60.1", default-
 graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.60.1", default-features = false }
 
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-email-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-s3-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-server-console = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-test-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+email-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+observability = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+s3-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+server-console = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+test-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
 
 ## Open Data Fabric
-odf = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false, package = "opendatafabric" }
+odf = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false, package = "opendatafabric" }
 
 # Domain
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-search = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-search = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
 
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
 
 # E2E: kamu-cli
-kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
-kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.231.0", version = "0.231.0", default-features = false }
+kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
+kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.231.0", default-features = false }
 
 # E2E: kamu-node
 kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.60.1", default-features = false }

--- a/src/app/api-server/src/app.rs
+++ b/src/app/api-server/src/app.rs
@@ -278,16 +278,27 @@ pub async fn init_dependencies(
         network_ns: config.engine.network_ns,
     });
 
-    b.add::<kamu::EngineProvisionerLocal>();
-    b.add_value(kamu::EngineProvisionerLocalConfig {
-        max_concurrency: config.engine.max_concurrency,
-        start_timeout: config.engine.start_timeout.into(),
-        shutdown_timeout: config.engine.shutdown_timeout.into(),
-        spark_image: config.engine.images.spark,
-        flink_image: config.engine.images.flink,
-        datafusion_image: config.engine.images.datafusion,
-        risingwave_image: config.engine.images.risingwave,
-    });
+    // Engine config
+    {
+        b.add::<kamu::EngineProvisionerLocal>();
+        b.add_value(kamu::EngineProvisionerLocalConfig {
+            max_concurrency: config.engine.max_concurrency,
+            start_timeout: config.engine.start_timeout.into(),
+            shutdown_timeout: config.engine.shutdown_timeout.into(),
+            spark_image: config.engine.images.spark,
+            flink_image: config.engine.images.flink,
+            datafusion_image: config.engine.images.datafusion,
+            risingwave_image: config.engine.images.risingwave,
+        });
+
+        let (ingest_config, batch_config, compact_config) =
+            config.engine.datafusion_embedded.into_system()?;
+
+        b.add_value(ingest_config);
+        b.add_value(batch_config);
+        b.add_value(compact_config);
+    }
+    //
 
     b.add_value(config.protocol.ipfs.into_gateway_config());
     b.add_value(kamu::utils::ipfs_wrapper::IpfsClient::default());

--- a/src/app/api-server/src/app.rs
+++ b/src/app/api-server/src/app.rs
@@ -136,6 +136,7 @@ pub async fn run(args: cli::Cli, config: config::ApiServerConfig) -> Result<(), 
                 c.flightsql_port,
                 args.e2e_output_data_path,
                 e2e_http_port,
+                c.read_only,
             )
             .cast(),
         ),

--- a/src/app/api-server/src/cli.rs
+++ b/src/app/api-server/src/cli.rs
@@ -65,6 +65,10 @@ pub struct Run {
     /// Expose Flight SQL server on specific port
     #[arg(long)]
     pub flightsql_port: Option<u16>,
+
+    /// Run server in read-only mode where it will not write to a database
+    #[arg(long)]
+    pub read_only: bool,
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/stacks/observability/README.md
+++ b/stacks/observability/README.md
@@ -1,0 +1,15 @@
+# Observability Stack
+Allows you to spawn a local observability stack that includes Loki, Tempo, and Grafana so you could test logging and tracing locally.
+
+Run the stack:
+```sh
+docker-compose up
+```
+
+Run the server:
+```sh
+KAMU_OTEL_OTLP_ENDPOINT=http://localhost:4317 <your normal run command>
+```
+
+## Issues
+Currently we run server outside of `docker-compose` so its logs go into `stderr` and won't make it into Loki. Only OTLP traces will. We need to figure out how this can be fixed without sacrificing the convenience of local testing.

--- a/stacks/observability/configs/grafana-datasources.yaml
+++ b/stacks/observability/configs/grafana-datasources.yaml
@@ -1,0 +1,37 @@
+apiVersion: 1
+
+datasources:
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    access: proxy
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: false
+    apiVersion: 1
+    jsonData:
+      httpMethod: GET
+      serviceMap:
+        datasourceUid: prometheus
+
+  - name: Loki
+    type: loki
+    uid: loki
+    access: proxy
+    orgId: 1
+    url: http://loki:3100
+    basicAuth: false
+    isDefault: true
+    version: 1
+    editable: false
+    jsonData:
+      derivedFields:
+        - datasourceUid: tempo
+          matcherRegex: trace_id
+          matcherType: label
+          name: trace_id
+          url: $${__value.raw}
+          urlDisplayLabel: View trace

--- a/stacks/observability/configs/loki.yaml
+++ b/stacks/observability/configs/loki.yaml
@@ -1,0 +1,29 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  ring:
+    instance_addr: 127.0.0.1
+    kvstore:
+      store: inmemory
+  replication_factor: 1
+  path_prefix: /loki
+
+schema_config:
+  configs:
+  - from: 2020-05-15
+    store: tsdb
+    object_store: filesystem
+    schema: v13
+    index:
+      prefix: index_
+      period: 24h
+
+storage_config:
+  filesystem:
+    directory: /tmp/loki/chunks
+
+limits_config:
+  allow_structured_metadata: true

--- a/stacks/observability/configs/otel-collector.yaml
+++ b/stacks/observability/configs/otel-collector.yaml
@@ -1,0 +1,17 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+
+exporters:
+  otlp:
+    endpoint: tempo:4317
+    tls:
+      insecure: true
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]

--- a/stacks/observability/configs/promtail.yaml
+++ b/stacks/observability/configs/promtail.yaml
@@ -1,0 +1,35 @@
+server:
+  http_listen_port: 9080
+  grpc_listen_port: 0
+
+positions:
+  filename: /tmp/positions.yaml
+
+clients:
+  - url: http://loki:3100/loki/api/v1/push
+
+scrape_configs:
+  - job_name: docker
+    docker_sd_configs:
+      - host: unix:///var/run/docker.sock
+        refresh_interval: 5s
+    relabel_configs:
+      - source_labels: ['__meta_docker_container_name']
+        regex: '/(.*)'
+        target_label: 'container'
+    pipeline_stages:
+      - match:
+          selector: '{container="observability-prototype-app-1"}'
+          stages:
+            - json:
+                expressions:
+                  timestamp: timestamp
+                  level: level
+                  trace_id: 'spans[0].trace_id'
+            - timestamp:
+                source: timestamp
+                format: RFC3339
+            - labels:
+                level:
+            - structured_metadata:
+                trace_id:

--- a/stacks/observability/configs/tempo.yaml
+++ b/stacks/observability/configs/tempo.yaml
@@ -1,0 +1,55 @@
+stream_over_http_enabled: true
+server:
+  http_listen_port: 3200
+  log_level: info
+
+query_frontend:
+  search:
+    duration_slo: 5s
+    throughput_bytes_slo: 1.073741824e+09
+  trace_by_id:
+    duration_slo: 5s
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+
+
+ingester:
+  max_block_duration: 5m               # cut the headblock when this much time passes. this is being set for demo purposes and should probably be left alone normally
+
+compactor:
+  compaction:
+    block_retention: 1h                # overall Tempo trace retention. set for demo purposes
+
+# metrics_generator:
+#   registry:
+#     external_labels:
+#       source: tempo
+#       cluster: docker-compose
+#   storage:
+#     path: /var/tempo/generator/wal
+#     remote_write:
+#       - url: http://prometheus:9090/api/v1/write
+#         send_exemplars: true
+#   traces_storage:
+#     path: /var/tempo/generator/traces
+
+storage:
+  trace:
+    backend: local                     # backend configuration to use
+    wal:
+      path: /var/tempo/wal             # where to store the wal locally
+    local:
+      path: /var/tempo/blocks
+
+# overrides:
+#   defaults:
+#     metrics_generator:
+#       processors: [service-graphs, span-metrics, local-blocks] # enables metrics generator
+  

--- a/stacks/observability/docker-compose.yaml
+++ b/stacks/observability/docker-compose.yaml
@@ -1,0 +1,50 @@
+services:
+  otel-collector:
+    image: "otel/opentelemetry-collector:latest"
+    command: ["--config=/etc/otel-collector.yaml"]
+    volumes:
+      - "./configs/otel-collector.yaml:/etc/otel-collector.yaml"
+    depends_on:
+      - tempo
+      - loki
+
+  promtail:
+    image: grafana/promtail:latest
+    volumes:
+      - "./configs/promtail.yaml:/etc/promtail/config.yml:ro"
+      - "/run/docker.sock:/run/docker.sock:ro"
+    command: -config.file=/etc/promtail/config.yml
+    depends_on:
+      - loki
+
+  tempo:
+    image: "grafana/tempo:latest"
+    command: ["-config.file=/etc/tempo.yaml"]
+    volumes:
+      - "./configs/tempo.yaml:/etc/tempo.yaml"
+    ports:
+      - "4317:4317" # otlp grpc
+      - "4318:4318" # otlp http
+
+  loki:
+    image: grafana/loki:latest
+    ports:
+      - "3100:3100"
+    volumes:
+      - ./configs/loki.yaml:/etc/loki/local-config.yaml
+    command: -config.file=/etc/loki/local-config.yaml
+
+  grafana:
+    image: "grafana/grafana:latest"
+    volumes:
+      - ./configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_AUTH_DISABLE_LOGIN_FORM=true
+      - GF_FEATURE_TOGGLES_ENABLE=traceqlEditor
+    ports:
+      - "3000:3000"
+    depends_on:
+      - tempo
+      - loki


### PR DESCRIPTION
Builds on top of: https://github.com/kamu-data/kamu-cli/pull/1173

Includes:
- Externalized Datafusion config
- `run --read-only` mode that allows to run api-server without starting flows, tasks and other sub-systems to safely run it locally while pointing at real environment database
  - This is super primitive currently, but can be improved in future by restricting DI, or creating RDS user that doesn't have write access to DB
- A `docker-compose` project that allows to start local observability stack (grafana, loki, tempo)