### PR TITLE
Release (minor): 0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,8 +36,8 @@ Recommendation: for ease of reading, use the following order:
   - `Datasets::role()`: returns the current user's role in relation to the dataset
   - GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias validation in multi-tenant mode.
 ### Changed
-- E2E, `kamu-node-e2e-repo-tests`: remove a `kamu-api-server` dependency 
-    that did not cause the `kamu-api-server` binary to be rebuilt.
+- GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: `dataset_visibility` is now mandatory.
+- `kamu push/pull` command with `--force` flag now does not allow overwriting of seed block
 ### Fixed
 - Multiple performance improvements in batch queries to avoid unnecessary metadata scanning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## [Unreleased]
+## [0.62.0] - 2025-04-09
 ### Added
 - Automatically indexing key dataset blocks in the database for quicker navigation:
    - indexing all previously stored datasets at startup

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Recommendation: for ease of reading, use the following order:
 ### Changed
 - E2E, `kamu-node-e2e-repo-tests`: remove a `kamu-api-server` dependency 
     that did not cause the `kamu-api-server` binary to be rebuilt.
+- Upgraded to latest version of `dill=0.13`.
 
 ## [0.61.1] - 2025-04-08
 ### Added
@@ -35,8 +36,8 @@ Recommendation: for ease of reading, use the following order:
   - `Datasets::role()`: returns the current user's role in relation to the dataset
   - GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias validation in multi-tenant mode.
 ### Changed
-- GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: `dataset_visibility` is now mandatory.
-- `kamu push/pull` command with `--force` flag now does not allow overwriting of seed block
+- E2E, `kamu-node-e2e-repo-tests`: remove a `kamu-api-server` dependency 
+    that did not cause the `kamu-api-server` binary to be rebuilt.
 ### Fixed
 - Multiple performance improvements in batch queries to avoid unnecessary metadata scanning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,7 +45,7 @@ Recommendation: for ease of reading, use the following order:
 ### Fixed 
 - Correct api version
 
-## [0.60.0] - 2025-03-31- 2025-03-31
+## [0.60.0] - 2025-03-31
 ### Changed
 - Trigger dependent dataset flows on Http `/ingest` and on smart transfer protocol dataset push
 - `DatasetSummary` files replaced with `DatasetStatistics` stored in the database 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ Recommendation: for ease of reading, use the following order:
    - indexing new changes to datasets incrementally, whenever HEAD advances
 - Metadata chain visiting algorithm can now use the key blocks cached in the database
    to efficiently implement iteration over key blocks, when data events are not needed
+### Changed
+- E2E, `kamu-node-e2e-repo-tests`: remove a `kamu-api-server` dependency 
+    that did not cause the `kamu-api-server` binary to be rebuilt.
 
 ## [0.61.1] - 2025-04-08
 ### Added
@@ -26,7 +29,8 @@ Recommendation: for ease of reading, use the following order:
 
 ## [0.61.0] - 2025-04-08
 ### Added
-- New `engine.datafusionEmbedded` config section allows to pass custom DataFusion settings when engine is used in igest, batch query, and compaction contexts.
+- New `engine.datafusionEmbedded` config section allows to pass custom DataFusion settings 
+    when engine is used in ingest, batch query, and compaction contexts.
 - GQL: 
   - `Datasets::role()`: returns the current user's role in relation to the dataset
   - GQL: `DatasetsMut::create_empty()` & `DatasetsMut::create_from_snapshot()`: alias validation in multi-tenant mode.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1475,7 +1475,7 @@ dependencies = [
 [[package]]
 name = "async-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2580,7 +2580,7 @@ dependencies = [
 [[package]]
 name = "common-macros"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2686,7 +2686,7 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 [[package]]
 name = "container-runtime"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3009,7 +3009,7 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 [[package]]
 name = "database-common"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3035,7 +3035,7 @@ dependencies = [
 [[package]]
 name = "database-common-macros"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3897,7 +3897,7 @@ dependencies = [
 [[package]]
 name = "email-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -3946,7 +3946,7 @@ dependencies = [
 [[package]]
 name = "enum-variants"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 
 [[package]]
 name = "env_filter"
@@ -4010,7 +4010,7 @@ dependencies = [
 [[package]]
 name = "event-sourcing"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4024,7 +4024,7 @@ dependencies = [
 [[package]]
 name = "event-sourcing-macros"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4113,7 +4113,7 @@ dependencies = [
 [[package]]
 name = "file-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 
 [[package]]
 name = "filetime"
@@ -4783,7 +4783,7 @@ dependencies = [
 [[package]]
 name = "http-common"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "axum 0.8.1",
  "http 1.3.1",
@@ -5166,7 +5166,7 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 [[package]]
 name = "init-on-startup"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5210,7 +5210,7 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 [[package]]
 name = "internal-error"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -5348,7 +5348,7 @@ dependencies = [
 [[package]]
 name = "kamu"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5417,7 +5417,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "base32",
@@ -5446,7 +5446,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5463,7 +5463,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5483,7 +5483,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5509,7 +5509,7 @@ dependencies = [
 [[package]]
 name = "kamu-accounts-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5529,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5553,7 +5553,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-flight-sql"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5582,7 +5582,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-graphql"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5617,7 +5617,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-http"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5672,7 +5672,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-oauth"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5690,7 +5690,7 @@ dependencies = [
 [[package]]
 name = "kamu-adapter-odata"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -5806,7 +5806,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5821,7 +5821,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5832,7 +5832,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5845,7 +5845,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5864,7 +5864,7 @@ dependencies = [
 [[package]]
 name = "kamu-auth-rebac-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5877,7 +5877,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-common"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5909,7 +5909,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-common-macros"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -5918,7 +5918,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "chrono",
  "database-common",
@@ -5946,7 +5946,7 @@ dependencies = [
 [[package]]
 name = "kamu-cli-puppet"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5967,7 +5967,7 @@ dependencies = [
 [[package]]
 name = "kamu-core"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5999,7 +5999,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6025,7 +6025,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6042,7 +6042,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6061,7 +6061,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6095,7 +6095,7 @@ dependencies = [
 [[package]]
 name = "kamu-datasets-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6115,7 +6115,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6141,7 +6141,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6158,7 +6158,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6176,7 +6176,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6203,7 +6203,7 @@ dependencies = [
 [[package]]
 name = "kamu-flow-system-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6221,7 +6221,7 @@ dependencies = [
 [[package]]
 name = "kamu-ingest-datafusion"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6247,7 +6247,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -6260,7 +6260,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6275,7 +6275,7 @@ dependencies = [
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6438,7 +6438,7 @@ dependencies = [
 [[package]]
 name = "kamu-search"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "futures",
@@ -6451,7 +6451,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-openai"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-openai",
  "async-trait",
@@ -6466,7 +6466,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-qdrant"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "container-runtime",
@@ -6483,7 +6483,7 @@ dependencies = [
 [[package]]
 name = "kamu-search-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -6505,7 +6505,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6525,7 +6525,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6538,7 +6538,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-postgres"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6554,7 +6554,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-services"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6578,7 +6578,7 @@ dependencies = [
 [[package]]
 name = "kamu-task-system-sqlite"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6992,7 +6992,7 @@ dependencies = [
 [[package]]
 name = "messaging-outbox"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7103,7 +7103,7 @@ dependencies = [
 [[package]]
 name = "multiformats"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7360,7 +7360,7 @@ dependencies = [
 [[package]]
 name = "observability"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -7430,7 +7430,7 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 [[package]]
 name = "opendatafabric"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -7446,7 +7446,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-data-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -7469,7 +7469,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-dataset"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7495,7 +7495,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-dataset-impl"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7529,7 +7529,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-metadata"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7560,7 +7560,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7579,7 +7579,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-http"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7599,7 +7599,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-inmem"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7615,7 +7615,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-lfs"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7635,7 +7635,7 @@ dependencies = [
 [[package]]
 name = "opendatafabric-storage-s3"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8714,7 +8714,7 @@ dependencies = [
 [[package]]
 name = "random-names"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9231,7 +9231,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 [[package]]
 name = "s3-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -9513,7 +9513,7 @@ dependencies = [
 [[package]]
 name = "server-console"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "axum 0.8.1",
@@ -10234,7 +10234,7 @@ dependencies = [
 [[package]]
 name = "test-utils"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "axum 0.8.1",
  "container-runtime",
@@ -10350,7 +10350,7 @@ dependencies = [
 [[package]]
 name = "time-source"
 version = "0.233.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
+source = "git+https://github.com/kamu-data/kamu-cli?tag=v0.233.0#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3880,7 +3880,7 @@ dependencies = [
 
 [[package]]
 name = "email-gateway"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -4413,7 +4413,7 @@ checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "graceful-shutdown"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -5715,7 +5715,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "arrow-flight",
  "askama",
@@ -6290,7 +6290,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-common"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -6321,7 +6321,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-common-macros"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6330,7 +6330,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-postgres"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -6345,7 +6345,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-repo-tests"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "indoc 2.0.6",
  "kamu-accounts",
@@ -6360,7 +6360,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-sqlite"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -6375,7 +6375,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-puppet"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -6389,7 +6389,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-oracle-provider"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -6421,7 +6421,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.61.1"
+version = "0.62.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,8 +1474,8 @@ dependencies = [
 
 [[package]]
 name = "async-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "tokio",
@@ -2579,8 +2579,8 @@ dependencies = [
 
 [[package]]
 name = "common-macros"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -2685,8 +2685,8 @@ checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
 name = "container-runtime"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -3008,8 +3008,8 @@ checksum = "575f75dfd25738df5b91b8e43e14d44bda14637a58fae779fd2b064f8bf3e010"
 
 [[package]]
 name = "database-common"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -3034,8 +3034,8 @@ dependencies = [
 
 [[package]]
 name = "database-common-macros"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -3694,9 +3694,9 @@ dependencies = [
 
 [[package]]
 name = "dill"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d035bd2279d2c1c7256cc1ecabfa82100bc12e9658387d9c1cf392ed88aebb10"
+checksum = "b077f467a5f987f57527261323765362158b727676cfed691eebd77a95bedd41"
 dependencies = [
  "dill-impl",
  "multimap",
@@ -3705,9 +3705,9 @@ dependencies = [
 
 [[package]]
 name = "dill-impl"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3513682eafe10921e4acd6d7e11e62a56f3b60e8669a005edd6c399ede3a169"
+checksum = "9972accc6b2aa51283d940ed474b240f727a86fe56d8787964fa981895987758"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3896,8 +3896,8 @@ dependencies = [
 
 [[package]]
 name = "email-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "serde",
  "thiserror 2.0.12",
@@ -3945,8 +3945,8 @@ dependencies = [
 
 [[package]]
 name = "enum-variants"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 
 [[package]]
 name = "env_filter"
@@ -4009,8 +4009,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -4023,8 +4023,8 @@ dependencies = [
 
 [[package]]
 name = "event-sourcing-macros"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -4112,8 +4112,8 @@ dependencies = [
 
 [[package]]
 name = "file-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 
 [[package]]
 name = "filetime"
@@ -4782,8 +4782,8 @@ dependencies = [
 
 [[package]]
 name = "http-common"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "axum 0.8.1",
  "http 1.3.1",
@@ -5165,8 +5165,8 @@ checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "init-on-startup"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5209,8 +5209,8 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "internal-error"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "thiserror 2.0.12",
 ]
@@ -5347,8 +5347,8 @@ dependencies = [
 
 [[package]]
 name = "kamu"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "alloy",
  "async-recursion",
@@ -5416,8 +5416,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "base32",
@@ -5445,8 +5445,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -5462,8 +5462,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5482,8 +5482,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "argon2",
  "async-trait",
@@ -5508,8 +5508,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-accounts-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5528,8 +5528,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-auth-oso-rebac"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5552,8 +5552,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-flight-sql"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -5581,8 +5581,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-graphql"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5616,8 +5616,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-http"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "aws-sdk-s3",
@@ -5671,8 +5671,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-oauth"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5689,8 +5689,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-adapter-odata"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -5805,8 +5805,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "internal-error",
@@ -5820,8 +5820,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5831,8 +5831,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5844,8 +5844,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -5863,8 +5863,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-auth-rebac-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -5876,8 +5876,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "async-trait",
@@ -5908,8 +5908,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-common-macros"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "quote",
  "syn 2.0.100",
@@ -5917,8 +5917,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-e2e-repo-tests"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "chrono",
  "database-common",
@@ -5945,8 +5945,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-cli-puppet"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -5966,8 +5966,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-core"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -5979,7 +5979,6 @@ dependencies = [
  "file-utils",
  "futures",
  "internal-error",
- "itertools 0.14.0",
  "kamu-datasets",
  "mockall",
  "object_store",
@@ -5999,8 +5998,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -6025,8 +6024,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6042,8 +6041,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6061,8 +6060,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "bytes",
@@ -6095,8 +6094,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-datasets-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6115,8 +6114,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6141,8 +6140,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6153,14 +6152,13 @@ dependencies = [
  "kamu-flow-system",
  "opendatafabric",
  "tokio",
- "tokio-stream",
  "tracing",
 ]
 
 [[package]]
 name = "kamu-flow-system-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6177,8 +6175,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6204,8 +6202,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-flow-system-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6222,8 +6220,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-ingest-datafusion"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6248,8 +6246,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -6261,8 +6259,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6276,8 +6274,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-messaging-outbox-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6349,21 +6347,15 @@ dependencies = [
 name = "kamu-node-e2e-repo-tests"
 version = "0.61.1"
 dependencies = [
- "chrono",
- "datafusion",
  "indoc 2.0.6",
  "kamu-accounts",
  "kamu-adapter-http",
- "kamu-api-server",
  "kamu-cli-e2e-common",
  "kamu-node-e2e-common",
  "opendatafabric",
- "paste",
  "pretty_assertions",
  "reqwest",
  "serde_json",
- "tempfile",
- "url",
 ]
 
 [[package]]
@@ -6445,8 +6437,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-search"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "futures",
@@ -6458,16 +6450,14 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-openai"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-openai",
  "async-trait",
  "dill",
- "futures",
  "internal-error",
  "kamu-search",
- "opendatafabric",
  "secrecy",
  "tokio",
  "tracing",
@@ -6475,28 +6465,25 @@ dependencies = [
 
 [[package]]
 name = "kamu-search-qdrant"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "container-runtime",
  "dill",
- "futures",
  "internal-error",
  "kamu-search",
- "opendatafabric",
  "qdrant-client",
  "rand 0.8.5",
  "serde_json",
  "tokio",
- "tonic",
  "tracing",
 ]
 
 [[package]]
 name = "kamu-search-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "dill",
@@ -6517,8 +6504,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -6537,8 +6524,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6550,8 +6537,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-postgres"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -6566,8 +6553,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-services"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "database-common",
@@ -6590,8 +6577,8 @@ dependencies = [
 
 [[package]]
 name = "kamu-task-system-sqlite"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7004,8 +6991,8 @@ dependencies = [
 
 [[package]]
 name = "messaging-outbox"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",
@@ -7115,8 +7102,8 @@ dependencies = [
 
 [[package]]
 name = "multiformats"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "base64 0.22.1",
  "bs58",
@@ -7372,8 +7359,8 @@ dependencies = [
 
 [[package]]
 name = "observability"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "axum 0.8.1",
@@ -7442,8 +7429,8 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "opendatafabric"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "opendatafabric-data-utils",
  "opendatafabric-dataset",
@@ -7458,8 +7445,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-data-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow",
  "arrow-digest",
@@ -7481,8 +7468,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7498,7 +7485,6 @@ dependencies = [
  "pin-project",
  "s3-utils",
  "serde",
- "serde_with",
  "strum 0.26.3",
  "thiserror 2.0.12",
  "tokio-stream",
@@ -7508,8 +7494,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-dataset-impl"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-stream",
  "async-trait",
@@ -7532,7 +7518,6 @@ dependencies = [
  "regex",
  "reqwest",
  "s3-utils",
- "serde_yaml",
  "thiserror 2.0.12",
  "time-source",
  "tokio",
@@ -7543,8 +7528,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-metadata"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "arrow",
  "base64 0.22.1",
@@ -7574,8 +7559,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7593,8 +7578,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-http"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7613,8 +7598,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-inmem"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7629,8 +7614,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-lfs"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -7649,8 +7634,8 @@ dependencies = [
 
 [[package]]
 name = "opendatafabric-storage-s3"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "async-utils",
@@ -8728,8 +8713,8 @@ dependencies = [
 
 [[package]]
 name = "random-names"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "rand 0.8.5",
 ]
@@ -9245,8 +9230,8 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "s3-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-utils",
  "aws-config",
@@ -9527,8 +9512,8 @@ dependencies = [
 
 [[package]]
 name = "server-console"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-graphql",
  "axum 0.8.1",
@@ -10248,8 +10233,8 @@ dependencies = [
 
 [[package]]
 name = "test-utils"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "axum 0.8.1",
  "container-runtime",
@@ -10364,8 +10349,8 @@ dependencies = [
 
 [[package]]
 name = "time-source"
-version = "0.232.0"
-source = "git+https://github.com/kamu-data/kamu-cli?branch=master#dee6abf081925ceeb1d9425b17e31653651af3db"
+version = "0.233.0"
+source = "git+https://github.com/kamu-data/kamu-cli?branch=master#d6271c50ccb08959ec4e51ac73c100761adf015e"
 dependencies = [
  "async-trait",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-api-server = { path = "src/app/api-server", version = "0.61.1", default-features = false }
+kamu-api-server = { path = "src/app/api-server", version = "0.62.0", default-features = false }
 
 # Utils
-email-gateway = { path = "src/utils/email-gateway", version = "0.61.1", default-features = false, features = [
+email-gateway = { path = "src/utils/email-gateway", version = "0.62.0", default-features = false, features = [
     "postmark",
 ] }
-graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.61.1", default-features = false }
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.62.0", default-features = false }
 
 # Utils (core)
 container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
@@ -94,13 +94,13 @@ kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0
 kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
 
 # E2E: kamu-node
-kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.61.1", default-features = false }
-kamu-node-e2e-common-macros = { path = "src/e2e/app/common-macros", version = "0.61.1", default-features = false }
-kamu-node-puppet = { path = "src/e2e/app/kamu-node-puppet", version = "0.61.1", default-features = false }
-kamu-node-e2e-repo-tests = { path = "src/e2e/app/repo-tests", version = "0.61.1", default-features = false }
+kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.62.0", default-features = false }
+kamu-node-e2e-common-macros = { path = "src/e2e/app/common-macros", version = "0.62.0", default-features = false }
+kamu-node-puppet = { path = "src/e2e/app/kamu-node-puppet", version = "0.62.0", default-features = false }
+kamu-node-e2e-repo-tests = { path = "src/e2e/app/repo-tests", version = "0.62.0", default-features = false }
 
 [workspace.package]
-version = "0.61.1"
+version = "0.62.0"
 edition = "2021"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,68 +30,68 @@ email-gateway = { path = "src/utils/email-gateway", version = "0.61.1", default-
 graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.61.1", default-features = false }
 
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-email-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-observability = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-s3-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-server-console = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-test-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+email-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+observability = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+s3-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+server-console = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+test-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
 
 ## Open Data Fabric
-odf = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false, package = "opendatafabric" }
+odf = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false, package = "opendatafabric" }
 
 # Domain
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-search = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-search = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
 
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false, features = ["lfs", "s3"] }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
 
 # E2E: kamu-cli
-kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
-kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.232.0", default-features = false }
+kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
 
 # E2E: kamu-node
 kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.61.1", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,68 +30,68 @@ email-gateway = { path = "src/utils/email-gateway", version = "0.61.1", default-
 graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.61.1", default-features = false }
 
 # Utils (core)
-container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-database-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-email-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-http-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-internal-error = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-observability = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-s3-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-server-console = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-test-utils = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-time-source = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+container-runtime = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+database-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+database-common-macros = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+email-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+http-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+init-on-startup = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+internal-error = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+messaging-outbox = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+observability = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+s3-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+server-console = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+test-utils = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+time-source = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
 
 ## Open Data Fabric
-odf = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false, package = "opendatafabric" }
+odf = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false, package = "opendatafabric" }
 
 # Domain
-kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-search = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-task-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-task-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-flow-system = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-flow-system-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-accounts = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-datasets = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-search = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-search-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
 
 # Infra
-kamu = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-accounts-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-accounts-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-accounts-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-accounts-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-auth-oso-rebac = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-flight-sql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-graphql = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-http = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-oauth = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-adapter-odata = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-auth-rebac-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-auth-rebac-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-auth-rebac-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-auth-rebac-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-datasets-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-datasets-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-datasets-services = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-datasets-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-flow-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-flow-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-flow-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-messaging-outbox-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-search-openai = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-search-qdrant = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-task-system-inmem = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-task-system-postgres = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-task-system-sqlite = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
 
 # E2E: kamu-cli
-kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
-kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.233.0", default-features = false }
+kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
+kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", tag = "v0.233.0", version = "0.233.0", default-features = false }
 
 # E2E: kamu-node
 kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.61.1", default-features = false }

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu Platform Version 0.61.1
+Licensed Work:             Kamu Platform Version 0.62.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may use the Licensed Work for any purpose,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may use the Licensed Work for any purpose,
                            Licensed Work where data or transformations are
                            controlled by such third parties.
 
-Change Date:               2029-04-08
+Change Date:               2029-04-09
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.61.1"
+    "version": "0.62.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -818,7 +818,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.61.1"
+    "version": "0.62.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -27,7 +27,7 @@ query-extensions-json = ["kamu/query-extensions-json"]
 
 
 [dependencies]
-dill = { version = "0.12", default-features = false }
+dill = { version = "0.13", default-features = false }
 
 container-runtime = { workspace = true }
 database-common = { workspace = true }

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -43,7 +43,15 @@ observability = { workspace = true, default-features = false, features = [
     "opentelemetry",
     "prometheus",
 ] }
-odf = { workspace = true, default-features = false }
+odf = { workspace = true, default-features = false, features = [
+    "arrow",
+    "http",
+    "lfs",
+    "s3",
+    "sqlx-postgres",
+    "sqlx-sqlite",
+    "utoipa",
+] }
 s3-utils = { workspace = true }
 server-console = { workspace = true }
 time-source = { workspace = true }

--- a/src/app/api-server/Cargo.toml
+++ b/src/app/api-server/Cargo.toml
@@ -69,7 +69,7 @@ kamu-auth-rebac-sqlite = { workspace = true }
 kamu-datasets = { workspace = true }
 kamu-datasets-inmem = { workspace = true }
 kamu-datasets-postgres = { workspace = true }
-kamu-datasets-services = { workspace = true }
+kamu-datasets-services = { workspace = true, default-features = false, features = ["lfs", "s3"] }
 kamu-datasets-sqlite = { workspace = true }
 kamu-flow-system = { workspace = true }
 kamu-flow-system-inmem = { workspace = true }

--- a/src/app/api-server/src/database.rs
+++ b/src/app/api-server/src/database.rs
@@ -153,19 +153,16 @@ fn init_database_password_provider(b: &mut CatalogBuilder, raw_db_config: &Datab
                     SecretString::from(raw_password_config.user_name.clone()),
                     SecretString::from(raw_password_config.raw_password.clone()),
                 ));
-                b.bind::<dyn DatabasePasswordProvider, DatabaseFixedPasswordProvider>();
             }
             DatabaseCredentialSourceConfig::AwsSecret(aws_secret_config) => {
                 b.add_builder(DatabaseAwsSecretPasswordProvider::builder(
                     aws_secret_config.secret_name.clone(),
                 ));
-                b.bind::<dyn DatabasePasswordProvider, DatabaseAwsSecretPasswordProvider>();
             }
             DatabaseCredentialSourceConfig::AwsIamToken(aws_iam_config) => {
                 b.add_builder(DatabaseAwsIamTokenProvider::builder(SecretString::from(
                     aws_iam_config.user_name.clone(),
                 )));
-                b.bind::<dyn DatabasePasswordProvider, DatabaseAwsIamTokenProvider>();
             }
         },
     }

--- a/src/app/api-server/tests/tests/notifiers/test_flow_progress_notifier.rs
+++ b/src/app/api-server/tests/tests/notifiers/test_flow_progress_notifier.rs
@@ -134,10 +134,8 @@ impl FlowProgressNotifierHarness {
             .add::<InMemoryDatasetEntryRepository>()
             .add::<DidGeneratorDefault>()
             .add::<SystemTimeSourceDefault>()
-            .add_builder(DatasetStorageUnitLocalFs::builder().with_root(datasets_dir))
-            .bind::<dyn odf::DatasetStorageUnit, DatasetStorageUnitLocalFs>()
+            .add_builder(DatasetStorageUnitLocalFs::builder(datasets_dir))
             .add::<odf::dataset::DatasetLfsBuilderDefault>()
-            .bind::<dyn odf::dataset::DatasetLfsBuilder, odf::dataset::DatasetLfsBuilderDefault>()
             .add_value(CurrentAccountSubject::new_test())
             .add_value(FlowAgentConfig::new(
                 TimeDelta::seconds(1),

--- a/src/app/oracle-provider/Cargo.toml
+++ b/src/app/oracle-provider/Cargo.toml
@@ -56,7 +56,7 @@ clap = { version = "4", default-features = false, features = [
 ] }
 ciborium = { version = "0.2", default-features = false }
 confique = { version = "0.3", default-features = false, features = ["yaml"] }
-dill = { version = "0.12", default-features = false }
+dill = { version = "0.13", default-features = false }
 duration-string = { version = "0.4", default-features = false, features = [
     "serde",
 ] }

--- a/src/e2e/app/repo-tests/Cargo.toml
+++ b/src/e2e/app/repo-tests/Cargo.toml
@@ -21,28 +21,17 @@ workspace = true
 doctest = false
 
 
-[package.metadata.cargo-udeps.ignore]
-normal = ["kamu-api-server"]
-
-
 [dependencies]
-# We add a dependency to ensure kamu-api-server is up to date before calling tests
-kamu-api-server = { workspace = true }
 kamu-cli-e2e-common = { workspace = true }
 kamu-node-e2e-common = { workspace = true }
 kamu-adapter-http = { workspace = true }
 kamu-accounts = { workspace = true }
 odf = { workspace = true }
 
-chrono = { version = "0.4", default-features = false }
 indoc = "2"
-paste = { version = "1", default-features = false }
 pretty_assertions = { version = "1" }
 reqwest = { version = "0.12", default-features = false, features = [] }
 serde_json = { version = "1", default-features = false }
-tempfile = { version = "3" }
-url = { version = "2", default-features = false }
-datafusion = { version = "46", default-features = false, features = [] }
 
 
 [dev-dependencies]

--- a/src/utils/email-gateway/Cargo.toml
+++ b/src/utils/email-gateway/Cargo.toml
@@ -31,7 +31,7 @@ email-utils = { workspace = true }
 internal-error = { workspace = true }
 
 async-trait = "0.1"
-dill = "0.12"
+dill = { version = "0.13", default-features = false }
 reqwest = { version = "0.12", default-features = false, features = ["json"] }
 secrecy = "0.10"
 serde = { version = "1", default-features = false }


### PR DESCRIPTION
### Added
- Automatically indexing key dataset blocks in the database for quicker navigation:
   - indexing all previously stored datasets at startup
   - indexing new changes to datasets incrementally, whenever HEAD advances
- Metadata chain visiting algorithm can now use the key blocks cached in the database
   to efficiently implement iteration over key blocks, when data events are not needed
### Changed
- E2E, `kamu-node-e2e-repo-tests`: remove a `kamu-api-server` dependency 
    that did not cause the `kamu-api-server` binary to be rebuilt.
- Upgraded to latest version of `dill=0.13`.