### PR TITLE
`kamu-api-server`: release (minor) `0.75.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Recommendation: for ease of reading, use the following order:
 - Fixed
 -->
 
-## Unreleased
+## [0.75.0] - 2025-09-24
 ### Upstream
 - Upgraded to [kamu `0.249.0`](https://github.com/kamu-data/kamu-cli/releases/tag/v0.249.0)
   - **Changed:** 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4537,7 +4537,7 @@ dependencies = [
 
 [[package]]
 name = "email-gateway"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "async-trait",
  "dill",
@@ -5183,7 +5183,7 @@ checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "graceful-shutdown"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "tokio",
  "tracing",
@@ -6896,7 +6896,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-api-server"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "arrow-flight",
  "askama",
@@ -7587,7 +7587,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-common"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "arrow-flight",
  "async-trait",
@@ -7617,7 +7617,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-common-macros"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7626,7 +7626,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-postgres"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7641,7 +7641,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-repo-tests"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "indoc 2.0.6",
  "kamu-accounts",
@@ -7656,7 +7656,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-e2e-sqlite"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "database-common",
  "indoc 2.0.6",
@@ -7671,7 +7671,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-node-puppet"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "assert_cmd",
  "async-trait",
@@ -7685,7 +7685,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-oracle-provider"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "alloy",
  "async-trait",
@@ -7718,7 +7718,7 @@ dependencies = [
 
 [[package]]
 name = "kamu-repo-tools"
-version = "0.74.1"
+version = "0.75.0"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,13 +21,13 @@ resolver = "2"
 [workspace.dependencies]
 
 # Apps
-kamu-api-server = { path = "src/app/api-server", version = "0.74.1", default-features = false }
+kamu-api-server = { path = "src/app/api-server", version = "0.75.0", default-features = false }
 
 # Utils
-email-gateway = { path = "src/utils/email-gateway", version = "0.74.1", default-features = false, features = [
+email-gateway = { path = "src/utils/email-gateway", version = "0.75.0", default-features = false, features = [
     "postmark",
 ] }
-graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.74.1", default-features = false }
+graceful-shutdown = { path = "src/utils/graceful-shutdown", version = "0.75.0", default-features = false }
 
 # Utils (core)
 container-runtime = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.249.0", default-features = false }
@@ -112,17 +112,17 @@ kamu-cli-e2e-common = { git = "https://github.com/kamu-data/kamu-cli", branch = 
 kamu-cli-e2e-repo-tests = { git = "https://github.com/kamu-data/kamu-cli", branch = "master", version = "0.249.0", default-features = false }
 
 # E2E: kamu-node
-kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.74.1", default-features = false }
-kamu-node-e2e-common-macros = { path = "src/e2e/app/common-macros", version = "0.74.1", default-features = false }
-kamu-node-puppet = { path = "src/e2e/app/kamu-node-puppet", version = "0.74.1", default-features = false }
-kamu-node-e2e-repo-tests = { path = "src/e2e/app/repo-tests", version = "0.74.1", default-features = false }
+kamu-node-e2e-common = { path = "src/e2e/app/common", version = "0.75.0", default-features = false }
+kamu-node-e2e-common-macros = { path = "src/e2e/app/common-macros", version = "0.75.0", default-features = false }
+kamu-node-puppet = { path = "src/e2e/app/kamu-node-puppet", version = "0.75.0", default-features = false }
+kamu-node-e2e-repo-tests = { path = "src/e2e/app/repo-tests", version = "0.75.0", default-features = false }
 
 # TODO: Updating aws-sdk version forces to update minio image version. 
 # Update it once we will modify our tests to be compatible with latest version
 aws-sdk-s3 = "=1.68.0"
 
 [workspace.package]
-version = "0.74.1"
+version = "0.75.0"
 edition = "2024"
 homepage = "https://github.com/kamu-data/kamu-platform"
 repository = "https://github.com/kamu-data/kamu-platform"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -11,7 +11,7 @@ Business Source License 1.1
 
 Licensor:                  Kamu Data, Inc.
 
-Licensed Work:             Kamu Node Version 0.74.1
+Licensed Work:             Kamu Node Version 0.75.0
                            The Licensed Work is © 2023 Kamu Data, Inc.
 
 Additional Use Grant:      You may not use the Licensed Work for a Data Service,
@@ -24,7 +24,7 @@ Additional Use Grant:      You may not use the Licensed Work for a Data Service,
                            Further, you may not distribute the Licensed Work
                            under a different name or a brand.
 
-Change Date:               2029-09-09
+Change Date:               2029-09-24
 
 Change License:            Apache License, Version 2.0
 

--- a/resources/openapi-mt.json
+++ b/resources/openapi-mt.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.74.1"
+    "version": "0.75.0"
   },
   "openapi": "3.1.0",
   "paths": {

--- a/resources/openapi.json
+++ b/resources/openapi.json
@@ -973,7 +973,7 @@
     },
     "termsOfService": "https://docs.kamu.dev/terms-of-service/",
     "title": "Kamu REST API",
-    "version": "0.74.1"
+    "version": "0.75.0"
   },
   "openapi": "3.1.0",
   "paths": {


### PR DESCRIPTION
## [0.75.0] - 2025-09-24
### Upstream
- Upgraded to [kamu `0.249.0`](https://github.com/kamu-data/kamu-cli/releases/tag/v0.249.0)
  - **Changed:** 
    - ([kamu-cli#1372](https://github.com/kamu-data/kamu-cli/pull/1372)): GQL: Performance improvement via query vectorization for APIs:
      - `Dataset::by_ids()`;
      - `DatasetMut::by_ids()`;
      - `Account::by_ids()`;
      - `AccountMut::by_ids()`.
    - Improved compatibility with EVM-based sources
    - Upgraded to `datafusion v50`
    - ([kamu-cli#1384](https://github.com/kamu-data/kamu-cli/pull/1384)) `GQL: Dataset::metadata().current_push_sources`: significant speed-up through iteration 
      over key blocks stored in the database 
    - ([kamu-cli#1384](https://github.com/kamu-data/kamu-cli/pull/1384)) General iteration optimizations based on the dataset type (root, derived). 
      Ability to disable hints during iteration.
    - ([kamu-cli#1384](https://github.com/kamu-data/kamu-cli/pull/1384)) `SearchActivePushSourcesVisitor`, `SearchActivePollingSourceVisitor`: accounting for the evolution of data 
      sources.