### PR TITLE
Log incoming GraphQL requests follow-up: update `kamu-api-server`'s `graphql_handler()`

### DIFF
--- a/src/app/api-server/src/http_server.rs
+++ b/src/app/api-server/src/http_server.rs
@@ -229,6 +229,9 @@ async fn graphql_handler(
         .data(account_entity_data_loader(&catalog))
         .data(dataset_handle_data_loader(&catalog))
         .data(catalog);
+
+    tracing::debug!(?graphql_request, "Incoming GraphQL request");
+
     let graphql_response: async_graphql_axum::GraphQLResponse =
         schema.execute(graphql_request).await.into();
 


### PR DESCRIPTION
Continues: 
- https://github.com/kamu-data/kamu-node/pull/306

Note: 
- I forgot that we have our own `graphql_handler()` in `kamu-api-server`...